### PR TITLE
EPMLABSBRN-105  Back-end: support child ids by defualt in GET requests for groups&series

### DIFF
--- a/src/main/kotlin/com/epam/brn/controller/SeriesController.kt
+++ b/src/main/kotlin/com/epam/brn/controller/SeriesController.kt
@@ -8,6 +8,7 @@ import com.epam.brn.dto.BaseResponseDto
 import com.epam.brn.service.SeriesService
 import io.swagger.annotations.Api
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
@@ -23,17 +24,17 @@ class SeriesController(@Autowired val seriesService: SeriesService) {
     fun getSeriesForGroup(
         @RequestParam(value = GROUP_ID) groupId: Long,
         @RequestParam(value = INCLUDE, defaultValue = "") include: String
-    ): BaseResponseDto {
+    ): ResponseEntity<BaseResponseDto> {
         val listDto = seriesService.findSeriesForGroup(groupId, include)
-        return BaseResponseDto(data = listDto)
+        return ResponseEntity.ok().body(BaseResponseDto(data = listDto))
     }
 
     @GetMapping("{$SERIES_ID}")
     fun getSeriesForId(
         @PathVariable(value = SERIES_ID) seriesId: Long,
         @RequestParam(value = INCLUDE, defaultValue = "") include: String
-    ): BaseResponseDto {
+    ): ResponseEntity<BaseResponseDto> {
         val seriesDto = seriesService.findSeriesForId(seriesId, include)
-        return BaseResponseDto(data = seriesDto)
+        return ResponseEntity.ok().body(BaseResponseDto(data = seriesDto))
     }
 }

--- a/src/main/kotlin/com/epam/brn/controller/SeriesController.kt
+++ b/src/main/kotlin/com/epam/brn/controller/SeriesController.kt
@@ -1,6 +1,5 @@
 package com.epam.brn.controller
 
-import com.epam.brn.constant.BrnFlags.INCLUDE
 import com.epam.brn.constant.BrnParams.GROUP_ID
 import com.epam.brn.constant.BrnParams.SERIES_ID
 import com.epam.brn.constant.BrnPath
@@ -21,20 +20,14 @@ import org.springframework.web.bind.annotation.RestController
 class SeriesController(@Autowired val seriesService: SeriesService) {
 
     @GetMapping
-    fun getSeriesForGroup(
-        @RequestParam(value = GROUP_ID) groupId: Long,
-        @RequestParam(value = INCLUDE, defaultValue = "") include: String
-    ): ResponseEntity<BaseResponseDto> {
-        val listDto = seriesService.findSeriesForGroup(groupId, include)
+    fun getSeriesForGroup(@RequestParam(value = GROUP_ID) groupId: Long): ResponseEntity<BaseResponseDto> {
+        val listDto = seriesService.findSeriesForGroup(groupId)
         return ResponseEntity.ok().body(BaseResponseDto(data = listDto))
     }
 
     @GetMapping("{$SERIES_ID}")
-    fun getSeriesForId(
-        @PathVariable(value = SERIES_ID) seriesId: Long,
-        @RequestParam(value = INCLUDE, defaultValue = "") include: String
-    ): ResponseEntity<BaseResponseDto> {
-        val seriesDto = seriesService.findSeriesForId(seriesId, include)
+    fun getSeriesForId(@PathVariable(value = SERIES_ID) seriesId: Long): ResponseEntity<BaseResponseDto> {
+        val seriesDto = seriesService.findSeriesForId(seriesId)
         return ResponseEntity.ok().body(BaseResponseDto(data = seriesDto))
     }
 }

--- a/src/main/kotlin/com/epam/brn/dto/ExerciseGroupDto.kt
+++ b/src/main/kotlin/com/epam/brn/dto/ExerciseGroupDto.kt
@@ -7,7 +7,7 @@ data class ExerciseGroupDto(
     @NotBlank
     val name: String?,
     val description: String?,
-    val series: MutableSet<SeriesDto> = HashSet()
+    val series: MutableSet<Long?> = HashSet()
 ) {
     constructor() : this(null, null, null)
 }

--- a/src/main/kotlin/com/epam/brn/dto/SeriesDto.kt
+++ b/src/main/kotlin/com/epam/brn/dto/SeriesDto.kt
@@ -11,13 +11,3 @@ data class SeriesDto(
     val description: String?,
     val exercises: MutableSet<Long?> = HashSet()
 )
-
-data class SeriesFullDto(
-    @NotBlank
-    val exerciseGroupId: Long? = null,
-    val id: Long?,
-    @NotBlank
-    val name: String,
-    val description: String?,
-    val exercises: MutableSet<ExerciseDto> = HashSet()
-)

--- a/src/main/kotlin/com/epam/brn/dto/SeriesDto.kt
+++ b/src/main/kotlin/com/epam/brn/dto/SeriesDto.kt
@@ -9,5 +9,15 @@ data class SeriesDto(
     @NotBlank
     val name: String,
     val description: String?,
+    val exercises: MutableSet<Long?> = HashSet()
+)
+
+data class SeriesFullDto(
+    @NotBlank
+    val exerciseGroupId: Long? = null,
+    val id: Long?,
+    @NotBlank
+    val name: String,
+    val description: String?,
     val exercises: MutableSet<ExerciseDto> = HashSet()
 )

--- a/src/main/kotlin/com/epam/brn/model/ExerciseGroup.kt
+++ b/src/main/kotlin/com/epam/brn/model/ExerciseGroup.kt
@@ -31,7 +31,7 @@ data class ExerciseGroup(
         id = id,
         name = name,
         description = description,
-        series = series.map { series -> series.toDtoWithExercises() }.toMutableSet()
+        series = series.map { series -> series.id }.toMutableSet()
     )
 
     override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/com/epam/brn/model/Series.kt
+++ b/src/main/kotlin/com/epam/brn/model/Series.kt
@@ -1,6 +1,7 @@
 package com.epam.brn.model
 
 import com.epam.brn.dto.SeriesDto
+import com.epam.brn.dto.SeriesFullDto
 import javax.persistence.Entity
 import javax.persistence.GeneratedValue
 import javax.persistence.GenerationType
@@ -33,18 +34,20 @@ data class Series(
     @OneToMany(mappedBy = "series", cascade = [(CascadeType.ALL)], fetch = FetchType.LAZY)
     val exercises: MutableSet<Exercise> = HashSet()
 ) {
-    fun toDtoWithExercises() = SeriesDto(
+    fun toDtoWithExerciseIds() = SeriesDto(
         exerciseGroupId = exerciseGroup.id,
         id = id,
         name = name,
         description = description,
-        exercises = exercises.map { exercise -> exercise.toDtoWithoutTasks() }.toMutableSet()
+        exercises = exercises.map { exercise -> exercise.id }.toMutableSet()
     )
-    fun toDtoWithoutExercises() = SeriesDto(
+
+    fun toDtoWithFullExercises() = SeriesFullDto(
         exerciseGroupId = exerciseGroup.id,
         id = id,
         name = name,
-        description = description
+        description = description,
+        exercises = exercises.map { exercise -> exercise.toDtoWithTasks() }.toMutableSet()
     )
 
     override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/com/epam/brn/model/Series.kt
+++ b/src/main/kotlin/com/epam/brn/model/Series.kt
@@ -1,18 +1,17 @@
 package com.epam.brn.model
 
 import com.epam.brn.dto.SeriesDto
-import com.epam.brn.dto.SeriesFullDto
+import javax.persistence.CascadeType
+import javax.persistence.Column
 import javax.persistence.Entity
+import javax.persistence.FetchType
 import javax.persistence.GeneratedValue
 import javax.persistence.GenerationType
 import javax.persistence.Id
 import javax.persistence.JoinColumn
-import javax.persistence.SequenceGenerator
-import javax.persistence.CascadeType
 import javax.persistence.ManyToOne
 import javax.persistence.OneToMany
-import javax.persistence.Column
-import javax.persistence.FetchType
+import javax.persistence.SequenceGenerator
 
 @Entity
 data class Series(
@@ -34,20 +33,12 @@ data class Series(
     @OneToMany(mappedBy = "series", cascade = [(CascadeType.ALL)], fetch = FetchType.LAZY)
     val exercises: MutableSet<Exercise> = HashSet()
 ) {
-    fun toDtoWithExerciseIds() = SeriesDto(
+    fun toDto() = SeriesDto(
         exerciseGroupId = exerciseGroup.id,
         id = id,
         name = name,
         description = description,
         exercises = exercises.map { exercise -> exercise.id }.toMutableSet()
-    )
-
-    fun toDtoWithFullExercises() = SeriesFullDto(
-        exerciseGroupId = exerciseGroup.id,
-        id = id,
-        name = name,
-        description = description,
-        exercises = exercises.map { exercise -> exercise.toDtoWithTasks() }.toMutableSet()
     )
 
     override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/com/epam/brn/service/SeriesService.kt
+++ b/src/main/kotlin/com/epam/brn/service/SeriesService.kt
@@ -1,6 +1,5 @@
 package com.epam.brn.service
 
-import com.epam.brn.dto.SeriesDto
 import com.epam.brn.exception.NoDataFoundException
 import com.epam.brn.repo.SeriesRepository
 import org.apache.logging.log4j.kotlin.logger
@@ -12,24 +11,22 @@ class SeriesService(private val seriesRepository: SeriesRepository) {
     val EXERCISES = "exercises"
     private val log = logger()
 
-    fun findSeriesForGroup(groupId: Long, include: String): List<SeriesDto> {
+    fun findSeriesForGroup(groupId: Long, include: String): List<Any> {
         log.debug("try to find series for groupId=$groupId")
         val series = seriesRepository.findByExerciseGroupLike(groupId)
-        var listDto: List<SeriesDto>
         if (include == EXERCISES)
-            listDto = series.map { seriesEntry -> seriesEntry.toDtoWithExercises() }
+            return series.map { seriesEntry -> seriesEntry.toDtoWithFullExercises() }
         else
-            listDto = series.map { seriesEntry -> seriesEntry.toDtoWithoutExercises() }
-        return listDto
+            return series.map { seriesEntry -> seriesEntry.toDtoWithExerciseIds() }
     }
 
-    fun findSeriesForId(seriesId: Long, include: String): SeriesDto {
+    fun findSeriesForId(seriesId: Long, include: String): Any {
         log.debug("try to find series for seriesId=$seriesId")
         val series = seriesRepository.findById(seriesId)
             .orElseThrow { NoDataFoundException("no series was found for id=$seriesId") }
         if (include == EXERCISES)
-            return series.toDtoWithExercises()
+            return series.toDtoWithFullExercises()
         else
-            return series.toDtoWithoutExercises()
+            return series.toDtoWithExerciseIds()
     }
 }

--- a/src/main/kotlin/com/epam/brn/service/SeriesService.kt
+++ b/src/main/kotlin/com/epam/brn/service/SeriesService.kt
@@ -1,5 +1,6 @@
 package com.epam.brn.service
 
+import com.epam.brn.dto.SeriesDto
 import com.epam.brn.exception.NoDataFoundException
 import com.epam.brn.repo.SeriesRepository
 import org.apache.logging.log4j.kotlin.logger
@@ -8,25 +9,18 @@ import org.springframework.stereotype.Service
 @Service
 class SeriesService(private val seriesRepository: SeriesRepository) {
 
-    val EXERCISES = "exercises"
     private val log = logger()
 
-    fun findSeriesForGroup(groupId: Long, include: String): List<Any> {
+    fun findSeriesForGroup(groupId: Long): List<SeriesDto> {
         log.debug("try to find series for groupId=$groupId")
         val series = seriesRepository.findByExerciseGroupLike(groupId)
-        if (include == EXERCISES)
-            return series.map { seriesEntry -> seriesEntry.toDtoWithFullExercises() }
-        else
-            return series.map { seriesEntry -> seriesEntry.toDtoWithExerciseIds() }
+        return series.map { seriesEntry -> seriesEntry.toDto() }
     }
 
-    fun findSeriesForId(seriesId: Long, include: String): Any {
+    fun findSeriesForId(seriesId: Long): SeriesDto {
         log.debug("try to find series for seriesId=$seriesId")
         val series = seriesRepository.findById(seriesId)
             .orElseThrow { NoDataFoundException("no series was found for id=$seriesId") }
-        if (include == EXERCISES)
-            return series.toDtoWithFullExercises()
-        else
-            return series.toDtoWithExerciseIds()
+        return series.toDto()
     }
 }

--- a/src/test/kotlin/com/epam/brn/controller/SeriesControllerTest.kt
+++ b/src/test/kotlin/com/epam/brn/controller/SeriesControllerTest.kt
@@ -24,13 +24,12 @@ internal class SeriesControllerTest {
         val groupId: Long = 1
         val series1 = SeriesDto(1, 1, "testName1", "testDescr1")
         val series2 = SeriesDto(1, 2, "testName2", "testDescr2")
-        val include = ""
         val listSeries = listOf(series1, series2)
-        Mockito.`when`(seriesService.findSeriesForGroup(groupId, include)).thenReturn(listSeries)
+        Mockito.`when`(seriesService.findSeriesForGroup(groupId)).thenReturn(listSeries)
         // WHEN
-        val actualResult = seriesController.getSeriesForGroup(groupId, include)
+        val actualResult = seriesController.getSeriesForGroup(groupId)
         // THEN
-        verify(seriesService).findSeriesForGroup(groupId, include)
+        verify(seriesService).findSeriesForGroup(groupId)
         assertTrue(actualResult.body.toString().contains("testName1"))
         assertTrue(actualResult.body.toString().contains("testName2"))
     }
@@ -40,12 +39,11 @@ internal class SeriesControllerTest {
         // GIVEN
         val seriesId: Long = 1
         val series = SeriesDto(1, seriesId, "testName", "testDescr")
-        val include = ""
-        Mockito.`when`(seriesService.findSeriesForId(seriesId, include)).thenReturn(series)
+        Mockito.`when`(seriesService.findSeriesForId(seriesId)).thenReturn(series)
         // WHEN
-        val actualResult = seriesController.getSeriesForId(1, include)
+        val actualResult = seriesController.getSeriesForId(1)
         // THEN
-        verify(seriesService).findSeriesForId(seriesId, include)
+        verify(seriesService).findSeriesForId(seriesId)
         assertTrue(actualResult.body.toString().contains("testName"))
     }
 }

--- a/src/test/kotlin/com/epam/brn/controller/SeriesControllerTest.kt
+++ b/src/test/kotlin/com/epam/brn/controller/SeriesControllerTest.kt
@@ -31,8 +31,8 @@ internal class SeriesControllerTest {
         val actualResult = seriesController.getSeriesForGroup(groupId, include)
         // THEN
         verify(seriesService).findSeriesForGroup(groupId, include)
-        assertTrue(actualResult.data.toString().contains("testName1"))
-        assertTrue(actualResult.data.toString().contains("testName2"))
+        assertTrue(actualResult.body.toString().contains("testName1"))
+        assertTrue(actualResult.body.toString().contains("testName2"))
     }
 
     @Test
@@ -46,6 +46,6 @@ internal class SeriesControllerTest {
         val actualResult = seriesController.getSeriesForId(1, include)
         // THEN
         verify(seriesService).findSeriesForId(seriesId, include)
-        assertTrue(actualResult.data.toString().contains("testName"))
+        assertTrue(actualResult.body.toString().contains("testName"))
     }
 }

--- a/src/test/kotlin/com/epam/brn/integration/SeriesControllerIT.kt
+++ b/src/test/kotlin/com/epam/brn/integration/SeriesControllerIT.kt
@@ -79,7 +79,6 @@ class SeriesControllerIT {
         val resultAction = mockMvc.perform(
             MockMvcRequestBuilders
                 .get("${BrnPath.SERIES}/$seriesId")
-                .param("include", "exercises")
                 .contentType(MediaType.APPLICATION_JSON_UTF8)
         )
         // THEN

--- a/src/test/kotlin/com/epam/brn/integration/SeriesControllerIT.kt
+++ b/src/test/kotlin/com/epam/brn/integration/SeriesControllerIT.kt
@@ -67,6 +67,7 @@ class SeriesControllerIT {
         val response = resultAction.andReturn().response.contentAsString
         Assertions.assertTrue(response.contains("распознование слов тест"))
         Assertions.assertTrue(response.contains("диахоничкеское слушание тест"))
+        Assertions.assertTrue(response.contains("exercises"))
     }
 
     @Test
@@ -87,5 +88,6 @@ class SeriesControllerIT {
             .andExpect(MockMvcResultMatchers.content().contentType(MediaType.APPLICATION_JSON_UTF8))
         val response = resultAction.andReturn().response.contentAsString
         Assertions.assertTrue(response.contains("распознование слов тест"))
+        Assertions.assertTrue(response.contains("exercises"))
     }
 }

--- a/src/test/kotlin/com/epam/brn/service/SeriesServiceTest.kt
+++ b/src/test/kotlin/com/epam/brn/service/SeriesServiceTest.kt
@@ -30,9 +30,9 @@ internal class SeriesServiceTest {
         val listSeries = listOf(series)
         `when`(seriesRepository.findByExerciseGroupLike(groupId)).thenReturn(listOf(series))
         // WHEN
-        val actualResult = seriesService.findSeriesForGroup(groupId, "")
+        val actualResult = seriesService.findSeriesForGroup(groupId)
         // THEN
-        val expectedResult = listSeries.map { seriesEntry -> seriesEntry.toDtoWithExerciseIds() }
+        val expectedResult = listSeries.map { seriesEntry -> seriesEntry.toDto() }
         assertEquals(expectedResult, actualResult)
         verify(seriesRepository).findByExerciseGroupLike(groupId)
     }
@@ -42,10 +42,9 @@ internal class SeriesServiceTest {
         // GIVEN
         val seriesId: Long = 1
         val series = mock(Series::class.java)
-        val include = "exercises"
         `when`(seriesRepository.findById(seriesId)).thenReturn(Optional.of(series))
         // WHEN
-        seriesService.findSeriesForId(seriesId, include)
+        seriesService.findSeriesForId(seriesId)
         // THEN
         verify(seriesRepository).findById(seriesId)
     }
@@ -54,10 +53,9 @@ internal class SeriesServiceTest {
     fun `should not get series for id`() {
         // GIVEN
         val seriesId: Long = 1
-        val include = "exercises"
         `when`(seriesRepository.findById(seriesId)).thenReturn(Optional.empty())
         // WHEN
-        assertThrows(NoDataFoundException::class.java) { seriesService.findSeriesForId(seriesId, include) }
+        assertThrows(NoDataFoundException::class.java) { seriesService.findSeriesForId(seriesId) }
         // THEN
         verify(seriesRepository).findById(seriesId)
     }

--- a/src/test/kotlin/com/epam/brn/service/SeriesServiceTest.kt
+++ b/src/test/kotlin/com/epam/brn/service/SeriesServiceTest.kt
@@ -32,7 +32,7 @@ internal class SeriesServiceTest {
         // WHEN
         val actualResult = seriesService.findSeriesForGroup(groupId, "")
         // THEN
-        val expectedResult = listSeries.map { seriesEntry -> seriesEntry.toDtoWithExercises() }
+        val expectedResult = listSeries.map { seriesEntry -> seriesEntry.toDtoWithExerciseIds() }
         assertEquals(expectedResult, actualResult)
         verify(seriesRepository).findByExerciseGroupLike(groupId)
     }


### PR DESCRIPTION
EPMLABSBRN-105 Back-end: support child ids by defualt in GET requests for groups&series

Description
response include child ids

