### PR TITLE
EPMLABSBRN-37 upgrade dockerization

### DIFF
--- a/Dockerfile_test
+++ b/Dockerfile_test
@@ -1,0 +1,12 @@
+FROM java:8
+
+RUN mkdir /brn
+
+WORKDIR brn
+
+RUN wget https://services.gradle.org/distributions/gradle-5.6.1-bin.zip -P /tmp
+
+RUN unzip -d /opt/gradle /tmp/gradle-*.zip
+
+ADD . /brn
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+# Backend
+clean:
+	rm -rf build out
+	rm -rf frontend/node_modules
+	rm -rf frontend/tmp
+
+docker_clean_app_images: stop
+	docker rmi brn_test db_brn brn
+
+docker_clean_test_containers:
+	docker-compose -f docker-compose-unit-test.yml down
+
+docker_unit_test: clean
+	docker-compose -f docker-compose-unit-test.yml up --build --force-recreate --exit-code-from brn-test
+
+start:
+	docker-compose up --build --force-recreate
+
+stop:
+	docker-compose down
+
+restart: clean stop start

--- a/docker-compose-unit-test.yml
+++ b/docker-compose-unit-test.yml
@@ -1,0 +1,21 @@
+version: '3.3'
+services:
+  db_brn-test:
+    container_name: db_brn-test
+    image: postgres
+    restart: always
+    environment:
+      POSTGRES_DB: brn
+      POSTGRES_USER: admin
+      POSTGRES_PASSWORD: admin
+  brn-test:
+    container_name: brn-test
+    command: ./gradlew clean test
+    build:
+      context: .
+      dockerfile: Dockerfile_test
+    environment:
+      POSTGRES_DB: brn
+      POSTGRES_USER: admin
+      POSTGRES_PASSWORD: admin
+      SPRING_PROFILE: dev

--- a/docker-compose-unit-test.yml
+++ b/docker-compose-unit-test.yml
@@ -18,4 +18,5 @@ services:
       POSTGRES_DB: brn
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin
+      DB_URL: db_brn-test
       SPRING_PROFILE: dev

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,6 +1,6 @@
 spring.datasource.username=${POSTGRES_USER:admin}
 spring.datasource.password=${POSTGRES_PASSWORD:admin}
-spring.datasource.url=jdbc:postgresql://localhost:5432/${POSTGRES_DB:brn}
+spring.datasource.url=jdbc:postgresql://${DB_URL:db_brn-test}:5432/${POSTGRES_DB:brn}
 spring.jpa.hibernate.ddl-auto=create
 
 logging.level.org.springframework=debug

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,6 +1,6 @@
 spring.datasource.username=${POSTGRES_USER:admin}
 spring.datasource.password=${POSTGRES_PASSWORD:admin}
-spring.datasource.url=jdbc:postgresql://${DB_URL:db_brn-test}:5432/${POSTGRES_DB:brn}
+spring.datasource.url=jdbc:postgresql://${DB_URL:localhost}:5432/${POSTGRES_DB:brn}
 spring.jpa.hibernate.ddl-auto=create
 
 logging.level.org.springframework=debug

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,4 +1,4 @@
 spring.datasource.username=${POSTGRES_USER}
 spring.datasource.password=${POSTGRES_PASSWORD}
-spring.datasource.url=jdbc:postgresql://10.66.216.143:5432/${POSTGRES_DB}
+spring.datasource.url=jdbc:postgresql://${DB_URL:db_brn}:5432/${POSTGRES_DB:brn}
 spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
[EPMLABSBRN-37](https://jira.epam.com/jira/browse/EPMLABSBRN-37)

**Description**:
Application Dockerization tuning.
Extracting unit tests execution to the separate compose file leads to the fact that we have a single point of truth in all possible situations when we have different results in test execution (at the environment side vs on local machines under Windows/Linux/macOS).
Makefile should make our workflow a bit more comfortable, especially in the case when someone a bit non-familiar with some specific commands and keys and we need to save our time and just use 
**make [command]** instead of a bit longer one.