### PR TITLE
EPMLABSBRN-106 Back-end: Get end-point `/exercises` should return tas…

### DIFF
--- a/src/main/kotlin/com/epam/brn/dto/ExerciseDto.kt
+++ b/src/main/kotlin/com/epam/brn/dto/ExerciseDto.kt
@@ -8,9 +8,7 @@ data class ExerciseDto(
     var description: String?,
     var level: Short? = 0,
     @JsonIgnore
-    var seriesId: Long? = null,
-    var tasks: MutableSet<TaskDto>? = HashSet(),
-    var available: Boolean? = null
-) {
-    constructor() : this(null, null, null, null, null, null)
-}
+    var seriesId: Long?,
+    var available: Boolean? = null,
+    var tasks: MutableSet<Long?> = HashSet()
+)

--- a/src/main/kotlin/com/epam/brn/model/Exercise.kt
+++ b/src/main/kotlin/com/epam/brn/model/Exercise.kt
@@ -31,21 +31,13 @@ data class Exercise(
     @OneToMany(mappedBy = "exercise", cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
     val tasks: MutableSet<Task> = HashSet()
 ) {
-    fun toDtoWithTasks(available: Boolean? = null) = ExerciseDto(
+    fun toDto(available: Boolean? = null) = ExerciseDto(
         seriesId = series.id,
         id = id,
         name = name,
         description = description,
-        tasks = tasks.map { task -> task.toDto() }.toMutableSet(),
-        available = available
-    )
-
-    fun toDtoWithoutTasks(available: Boolean? = null) = ExerciseDto(
-        seriesId = series.id,
-        id = id,
-        name = name,
-        description = description,
-        available = available
+        available = available,
+        tasks = tasks.map { task -> task.id }.toMutableSet()
     )
 
     override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/com/epam/brn/service/ExerciseService.kt
+++ b/src/main/kotlin/com/epam/brn/service/ExerciseService.kt
@@ -20,7 +20,7 @@ class ExerciseService(
 
     fun findExerciseById(exerciseID: Long): ExerciseDto {
         val exercise = exerciseRepository.findById(exerciseID)
-        return exercise.map { e -> e.toDtoWithoutTasks() }
+        return exercise.map { e -> e.toDto() }
             .orElseThrow { NoDataFoundException("Could not find requested exerciseID=$exerciseID") }
     }
 
@@ -33,13 +33,13 @@ class ExerciseService(
         log.debug("Searching available exercises for user=$userId")
         val exercisesIdList = studyHistoryRepository.getDoneExercisesIdList(userId)
         val history = exerciseRepository.findAll()
-        return emptyIfNull(history).map { x -> x.toDtoWithoutTasks(exercisesIdList.contains(x.id)) }
+        return emptyIfNull(history).map { x -> x.toDto(exercisesIdList.contains(x.id)) }
     }
 
     fun findExercisesByUserIdAndSeries(userId: Long, seriesId: Long): List<ExerciseDto> {
         log.debug("Searching available exercises for user=$userId with series=$seriesId")
         val exercisesIdList = studyHistoryRepository.getDoneExercisesIdList(seriesId, userId)
         val exercises = exerciseRepository.findExercisesBySeriesId(seriesId)
-        return emptyIfNull(exercises).map { x -> x.toDtoWithoutTasks(exercisesIdList.contains(x.id)) }
+        return emptyIfNull(exercises).map { x -> x.toDto(exercisesIdList.contains(x.id)) }
     }
 }

--- a/src/test/kotlin/com/epam/brn/controller/ExerciseControllerTest.kt
+++ b/src/test/kotlin/com/epam/brn/controller/ExerciseControllerTest.kt
@@ -24,7 +24,7 @@ internal class ExerciseControllerTest {
         // GIVEN
         val userId: Long = 1
         val seriesId: Long = 1
-        val exercise = ExerciseDto(1, "name", "desc", 1)
+        val exercise = ExerciseDto(1, "name", "desc", 1, 1)
         val listExercises = listOf(exercise)
         Mockito.`when`(exerciseService.findExercisesByUserIdAndSeries(userId, seriesId)).thenReturn(listExercises)
         // WHEN
@@ -40,7 +40,7 @@ internal class ExerciseControllerTest {
     fun `should get exercise by id`() {
         // GIVEN
         val exerciseID: Long = 1
-        val exercise = ExerciseDto(1, "exe", "desc")
+        val exercise = ExerciseDto(1, "exe", "desc", 1, 1)
         Mockito.`when`(exerciseService.findExerciseById(exerciseID)).thenReturn(exercise)
         // WHEN
         @Suppress("UNCHECKED_CAST")

--- a/src/test/kotlin/com/epam/brn/service/ExerciseServiceTest.kt
+++ b/src/test/kotlin/com/epam/brn/service/ExerciseServiceTest.kt
@@ -4,6 +4,7 @@ import com.epam.brn.dto.ExerciseDto
 import com.epam.brn.model.Exercise
 import com.epam.brn.repo.ExerciseRepository
 import com.epam.brn.repo.StudyHistoryRepository
+import com.nhaarman.mockito_kotlin.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -28,9 +29,9 @@ internal class ExerciseServiceTest {
     fun `should get exercises by user`() {
         // GIVEN
         val exerciseMock: Exercise = mock(Exercise::class.java)
-        val exerciseDtoMock = ExerciseDto()
+        val exerciseDtoMock = ExerciseDto(1, "name", "descr", 1, 1)
         val exerciseId = 1L
-        `when`(exerciseMock.toDtoWithoutTasks(true)).thenReturn(exerciseDtoMock)
+        `when`(exerciseMock.toDto(true)).thenReturn(exerciseDtoMock)
         `when`(exerciseMock.id).thenReturn(exerciseId)
         `when`(studyHistoryRepository.getDoneExercisesIdList(anyLong())).thenReturn(listOf(exerciseId))
         `when`(exerciseRepository.findAll()).thenReturn(listOf(exerciseMock))
@@ -38,16 +39,18 @@ internal class ExerciseServiceTest {
         val actualResult: List<ExerciseDto> = exerciseService.findExercisesByUserId(exerciseId)
         // THEN
         assertEquals(actualResult, listOf(exerciseDtoMock))
+        verify(exerciseRepository).findAll()
+        verify(studyHistoryRepository).getDoneExercisesIdList(anyLong())
     }
 
     @Test
     fun `should get exercises by user and series`() {
         // GIVEN
         val exerciseMock: Exercise = mock(Exercise::class.java)
-        val exerciseDtoMock = ExerciseDto()
+        val exerciseDtoMock = ExerciseDto(1, "name", "descr", 1, 1)
         val exerciseId = 1L
         val seriesId = 1L
-        `when`(exerciseMock.toDtoWithoutTasks(true)).thenReturn(exerciseDtoMock)
+        `when`(exerciseMock.toDto(true)).thenReturn(exerciseDtoMock)
         `when`(exerciseMock.id).thenReturn(exerciseId)
         `when`(studyHistoryRepository.getDoneExercisesIdList(anyLong(), anyLong())).thenReturn(listOf(exerciseId))
         `when`(exerciseRepository.findExercisesBySeriesId(seriesId)).thenReturn(listOf(exerciseMock))
@@ -55,18 +58,21 @@ internal class ExerciseServiceTest {
         val actualResult: List<ExerciseDto> = exerciseService.findExercisesByUserIdAndSeries(exerciseId, seriesId)
         // THEN
         assertEquals(actualResult, listOf(exerciseDtoMock))
+        verify(exerciseRepository).findExercisesBySeriesId(seriesId)
+        verify(studyHistoryRepository).getDoneExercisesIdList(anyLong(), anyLong())
     }
 
     @Test
     fun `should get exercise by id`() {
         // GIVEN
         val exerciseMock: Exercise = mock(Exercise::class.java)
-        val exerciseDtoMock = ExerciseDto()
-        `when`(exerciseMock.toDtoWithoutTasks()).thenReturn(exerciseDtoMock)
+        val exerciseDtoMock = ExerciseDto(1, "name", "descr", 1, 1)
+        `when`(exerciseMock.toDto()).thenReturn(exerciseDtoMock)
         `when`(exerciseRepository.findById(anyLong())).thenReturn(Optional.of(exerciseMock))
         // WHEN
         val actualResult: ExerciseDto = exerciseService.findExerciseById(1L)
         // THEN
         assertEquals(actualResult, exerciseDtoMock)
+        verify(exerciseRepository).findById(anyLong())
     }
 }


### PR DESCRIPTION
EPMLABSBRN-106 Back-end: Get end-point `/exercises` should return tasks ids by default

fix it
