### PR TITLE
EPMLABSBRN-136 add `/api` to all end-points

### DIFF
--- a/src/main/kotlin/com/epam/brn/constant/BrnPath.kt
+++ b/src/main/kotlin/com/epam/brn/constant/BrnPath.kt
@@ -2,12 +2,11 @@ package com.epam.brn.constant
 
 object BrnPath {
     const val HOME = "/home"
-    const val API = "/api"
-    const val USERS = API + "/users"
-    const val GROUPS = API + "/groups"
-    const val SERIES = API + "/series"
-    const val EXERCISES = API + "/exercises"
-    const val TASKS = API + "/tasks"
-    const val STUDY_HISTORIES = API + "/study-histories"
-    const val FILES = API +  "/files"
+    const val USERS = "/users"
+    const val GROUPS = "/groups"
+    const val SERIES = "/series"
+    const val EXERCISES = "/exercises"
+    const val TASKS = "/tasks"
+    const val STUDY_HISTORIES = "/study-histories"
+    const val FILES = "/files"
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,3 +19,5 @@ spring.flyway.enabled=false
 
 brn.task.files.path=/inputData/tasks
 brn.processed.files.path=/inputData/processed
+
+server.servlet.context-path=/api


### PR DESCRIPTION
EPMLABSBRN-136 add `/api` to all end-points

fixed: add property to application.property for it
