### PR TITLE
EPMLABSBRN-0 add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,59 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+
+# Common formats
+*.html text
+*.xml text
+*.css text
+*.js text
+*.properties text
+*.bat text
+*.rtf text
+
+# SQL scripts
+*.sql text
+
+# Java sources
+*.java text
+
+# Kotlin sources
+*.kt text
+
+# Jsf sources
+*.jsf text
+*.xhtml text
+
+# Action script and Flex
+*.as text
+*.mxml text
+*.actionScriptProperties text
+*.flexLibProperties text
+
+# Gradle build files
+*.gradle text
+
+# Google protocol buffers
+*.proto text
+
+# Miscellaneous
+*.rb text
+
+# Swg files are XML text, though more often they are handled in graphical editors, so can be skipped.
+*.swg -text
+
+# Declare files that will always have CRLF line endings on checkout.
+# *.sln text eol=crlf
+
+# Denote all files that are truly binary and should not be modified.
+*.mp3 binary
+*.png binary
+*.jpg binary
+*.gif binary
+*.swf binary
+*.jar binary
+
+*.scpt binary
+*.scssc binary


### PR DESCRIPTION
.gitattributes file in general controls
line ending on repository level and prevents
related error on different OS without need
of additional tools.

Without it people on different OS very likely will face issues
when IDE/editor automatically change line endings that lead
to full file modification.

It listing binaries files and can be used to set LF/CRLF
endings explicitly for each format.

See https://git-scm.com/docs/gitattributes for details