### PR TITLE
Epmlabsbrn 311 refactoring and issues exception advice

### DIFF
--- a/src/main/kotlin/com/epam/brn/controller/advice/ExceptionControllerAdvice.kt
+++ b/src/main/kotlin/com/epam/brn/controller/advice/ExceptionControllerAdvice.kt
@@ -3,8 +3,6 @@ package com.epam.brn.controller.advice
 import com.epam.brn.dto.BaseResponseDto
 import com.epam.brn.exception.EntityNotFoundException
 import com.epam.brn.exception.FileFormatException
-import java.io.IOException
-import java.lang.IllegalArgumentException
 import org.apache.logging.log4j.kotlin.logger
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -12,6 +10,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.security.authentication.BadCredentialsException
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
+import java.io.IOException
 
 @ControllerAdvice
 class ExceptionControllerAdvice {
@@ -71,11 +70,6 @@ class ExceptionControllerAdvice {
 
     fun makeInternalServerErrorResponseEntity(e: Throwable) = ResponseEntity
         .status(HttpStatus.INTERNAL_SERVER_ERROR)
-        .contentType(MediaType.APPLICATION_JSON)
-        .body(BaseResponseDto(errors = listOf(e.message.toString())))
-
-    fun makeForbiddenErrorResponseEntity(e: Throwable) = ResponseEntity
-        .status(HttpStatus.FORBIDDEN)
         .contentType(MediaType.APPLICATION_JSON)
         .body(BaseResponseDto(errors = listOf(e.message.toString())))
 

--- a/src/main/kotlin/com/epam/brn/controller/advice/ExceptionControllerAdvice.kt
+++ b/src/main/kotlin/com/epam/brn/controller/advice/ExceptionControllerAdvice.kt
@@ -19,7 +19,7 @@ class ExceptionControllerAdvice {
 
     @ExceptionHandler(EntityNotFoundException::class)
     fun handleEntityNotFoundException(e: EntityNotFoundException): ResponseEntity<BaseResponseDto> {
-        logger.error("Entity not found exception: ${e.message}", e)
+        logger.warn("Entity not found exception: ${e.message}", e)
         return ResponseEntity
             .status(HttpStatus.NOT_FOUND)
             .contentType(MediaType.APPLICATION_JSON)
@@ -28,7 +28,7 @@ class ExceptionControllerAdvice {
 
     @ExceptionHandler(FileFormatException::class)
     fun handleFileFormatException(e: FileFormatException): ResponseEntity<BaseResponseDto> {
-        logger.error("File format exception: ${e.message}", e)
+        logger.warn("File format exception: ${e.message}", e)
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
             .contentType(MediaType.APPLICATION_JSON)
@@ -37,7 +37,7 @@ class ExceptionControllerAdvice {
 
     @ExceptionHandler(IllegalArgumentException::class)
     fun handleIllegalArgumentException(e: IllegalArgumentException): ResponseEntity<BaseResponseDto> {
-        logger.error("IllegalArgumentException: ${e.message}", e)
+        logger.warn("IllegalArgumentException: ${e.message}", e)
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
             .contentType(MediaType.APPLICATION_JSON)
@@ -46,7 +46,7 @@ class ExceptionControllerAdvice {
 
     @ExceptionHandler(BadCredentialsException::class)
     fun handleBadCredentialsException(e: BadCredentialsException): ResponseEntity<BaseResponseDto> {
-        logger.error("Forbidden: ${e.message}", e)
+        logger.warn("Forbidden: ${e.message}", e)
         return ResponseEntity
             .status(HttpStatus.UNAUTHORIZED)
             .contentType(MediaType.APPLICATION_JSON)

--- a/src/main/kotlin/com/epam/brn/controller/advice/ExceptionControllerAdvice.kt
+++ b/src/main/kotlin/com/epam/brn/controller/advice/ExceptionControllerAdvice.kt
@@ -3,6 +3,7 @@ package com.epam.brn.controller.advice
 import com.epam.brn.dto.BaseResponseDto
 import com.epam.brn.exception.EntityNotFoundException
 import com.epam.brn.exception.FileFormatException
+import java.io.IOException
 import org.apache.logging.log4j.kotlin.logger
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -10,7 +11,6 @@ import org.springframework.http.ResponseEntity
 import org.springframework.security.authentication.BadCredentialsException
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
-import java.io.IOException
 
 @ControllerAdvice
 class ExceptionControllerAdvice {
@@ -44,37 +44,35 @@ class ExceptionControllerAdvice {
             .body(BaseResponseDto(errors = listOf(e.message.toString())))
     }
 
+    @ExceptionHandler(BadCredentialsException::class)
+    fun handleBadCredentialsException(e: BadCredentialsException): ResponseEntity<BaseResponseDto> {
+        logger.error("Forbidden: ${e.message}", e)
+        return ResponseEntity
+            .status(HttpStatus.UNAUTHORIZED)
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(BaseResponseDto(errors = listOf(e.message.toString())))
+    }
+
     @ExceptionHandler(UninitializedPropertyAccessException::class)
     fun handleUninitializedPropertyAccessException(e: Throwable): ResponseEntity<BaseResponseDto> {
-        logger.error("Internal exception: ${e.message}", e)
-        return makeInternalServerErrorResponseEntity(e)
+        return createInternalErrorResponse(e)
     }
 
     @ExceptionHandler(IOException::class)
     fun handleIOException(e: IOException): ResponseEntity<BaseResponseDto> {
-        logger.error("Internal exception: ${e.message}", e)
-        return makeInternalServerErrorResponseEntity(e)
-    }
-
-    @ExceptionHandler(BadCredentialsException::class)
-    fun handleBadCredentialsException(e: BadCredentialsException): ResponseEntity<BaseResponseDto> {
-        logger.error("Forbidden: ${e.message}", e)
-        return makeUnauthorizedErrorResponseEntity(e)
+        return createInternalErrorResponse(e)
     }
 
     @ExceptionHandler(Throwable::class)
     fun handleException(e: Throwable): ResponseEntity<BaseResponseDto> {
-        logger.error("Internal exception: ${e.message}", e)
-        return makeInternalServerErrorResponseEntity(e)
+        return createInternalErrorResponse(e)
     }
 
-    fun makeInternalServerErrorResponseEntity(e: Throwable) = ResponseEntity
-        .status(HttpStatus.INTERNAL_SERVER_ERROR)
-        .contentType(MediaType.APPLICATION_JSON)
-        .body(BaseResponseDto(errors = listOf(e.message.toString())))
-
-    fun makeUnauthorizedErrorResponseEntity(e: Throwable) = ResponseEntity
-        .status(HttpStatus.UNAUTHORIZED)
-        .contentType(MediaType.APPLICATION_JSON)
-        .body(BaseResponseDto(errors = listOf(e.message.toString())))
+    fun createInternalErrorResponse(e: Throwable): ResponseEntity<BaseResponseDto> {
+        logger.error("Internal exception: ${e.message}", e)
+        return ResponseEntity
+                    .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(BaseResponseDto(errors = listOf(e.message.toString())))
+    }
 }

--- a/src/test/kotlin/com/epam/brn/controller/advice/ExceptionControllerAdviceTest.kt
+++ b/src/test/kotlin/com/epam/brn/controller/advice/ExceptionControllerAdviceTest.kt
@@ -55,7 +55,7 @@ internal class ExceptionControllerAdviceTest {
         // GIVEN
         val exception = Exception("some test exception")
         // WHEN
-        val responseEntity = exceptionControllerAdvice.makeInternalServerErrorResponseEntity(exception)
+        val responseEntity = exceptionControllerAdvice.createInternalErrorResponse(exception)
         // THEN
         assertTrue((responseEntity.body as BaseResponseDto).errors.toString().contains("some test exception"))
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, responseEntity.statusCode)


### PR DESCRIPTION
EPMLABSBRN-311 update log levels
    
    For all cases that are not actual errors from user perspective
    log level was changed from `error` to `warn`
    (i.e. user can upload not valid info, or pass not valid param
    as part of normal program execution).

EPMLABSBRN-311 refactor ExceptionControllerAdvice
    
    - inline methods with 1 usage
    - extract duplicated code to separate method

EPMLABSBRN-311 remove unused code <eom>