### PR TITLE
EPMLABSBRN-221 rework StudyHistoryService to correctly handle incorrect user/exercise ids <eom>

### DIFF
--- a/src/main/kotlin/com/epam/brn/controller/StudyHistoryController.kt
+++ b/src/main/kotlin/com/epam/brn/controller/StudyHistoryController.kt
@@ -19,11 +19,18 @@ import org.springframework.web.bind.annotation.RestController
 class StudyHistoryController(@Autowired val studyHistoryService: StudyHistoryService) {
 
     @PostMapping
-    fun saveOrUpdateStudyHistory(
+    fun save(
         @Validated @RequestBody studyHistoryDto: StudyHistoryDto
     ): ResponseEntity<StudyHistoryDto> {
-        val studyHistoryResult = studyHistoryService.saveOrUpdateStudyHistory(studyHistoryDto)
-        return ResponseEntity.status(studyHistoryResult.responseCode!!).body(studyHistoryResult)
+
+        val existingHistory = studyHistoryService.findBy(studyHistoryDto.userId, studyHistoryDto.exerciseId)
+        if (existingHistory.isPresent) {
+            return ResponseEntity.ok()
+                .body(studyHistoryService.update(existingHistory.get(), studyHistoryDto))
+        }
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(studyHistoryService.create(studyHistoryDto))
     }
 
     @PatchMapping

--- a/src/main/kotlin/com/epam/brn/converter/StudyHistoryConverter.kt
+++ b/src/main/kotlin/com/epam/brn/converter/StudyHistoryConverter.kt
@@ -15,7 +15,7 @@ interface StudyHistoryConverter {
         nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_NULL,
         nullValueCheckStrategy = NullValueCheckStrategy.ALWAYS
     )
-    fun updateStudyHistory(studyHistoryDto: StudyHistoryDto, @MappingTarget studyHistory: StudyHistory)
+    fun updateStudyHistory(studyHistoryDto: StudyHistoryDto, @MappingTarget studyHistory: StudyHistory): StudyHistory
 
     @BeanMapping(
         nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE,

--- a/src/main/kotlin/com/epam/brn/dto/StudyHistoryDto.kt
+++ b/src/main/kotlin/com/epam/brn/dto/StudyHistoryDto.kt
@@ -2,7 +2,6 @@ package com.epam.brn.dto
 
 import java.time.LocalDateTime
 import javax.validation.constraints.NotNull
-import org.springframework.http.HttpStatus
 
 data class StudyHistoryDto(
     var id: Long? = null,
@@ -13,10 +12,15 @@ data class StudyHistoryDto(
     var startTime: LocalDateTime?,
     var endTime: LocalDateTime?,
     var tasksCount: Short?,
-    var repetitionIndex: Float?,
-    var responseCode: HttpStatus? = null
+    var repetitionIndex: Float?
 ) {
     override fun toString(): String {
-        return "StudyHistoryDto(userId=$userId, exerciseId=$exerciseId, startTime=$startTime, endTime=$endTime, doneTasksCount=$tasksCount, repetitionIndex=$repetitionIndex, responseCode=$responseCode)"
+        return "StudyHistoryDto(" +
+                "userId=$userId, " +
+                "exerciseId=$exerciseId, " +
+                "startTime=$startTime, " +
+                "endTime=$endTime, " +
+                "doneTasksCount=$tasksCount, " +
+                "repetitionIndex=$repetitionIndex)"
     }
 }

--- a/src/main/kotlin/com/epam/brn/repo/ExerciseRepository.kt
+++ b/src/main/kotlin/com/epam/brn/repo/ExerciseRepository.kt
@@ -9,5 +9,5 @@ import org.springframework.stereotype.Repository
 interface ExerciseRepository : JpaRepository<Exercise, Long> {
     fun findExercisesBySeriesId(seriesId: Long): List<Exercise>
     fun findExerciseByNameAndLevel(name: String, level: Int): Optional<Exercise>
-    override fun findById(seriesId: Long): Optional<Exercise>
+    override fun findById(id: Long): Optional<Exercise>
 }

--- a/src/main/kotlin/com/epam/brn/service/StudyHistoryService.kt
+++ b/src/main/kotlin/com/epam/brn/service/StudyHistoryService.kt
@@ -6,58 +6,70 @@ import com.epam.brn.exception.EntityNotFoundException
 import com.epam.brn.model.Exercise
 import com.epam.brn.model.StudyHistory
 import com.epam.brn.model.UserAccount
+import com.epam.brn.repo.ExerciseRepository
 import com.epam.brn.repo.StudyHistoryRepository
+import com.epam.brn.repo.UserAccountRepository
 import java.security.InvalidParameterException
-import javax.persistence.EntityManager
+import java.util.Optional
 import org.apache.logging.log4j.kotlin.logger
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 
 @Service
 class StudyHistoryService(
-    @Autowired val studyHistoryRepository: StudyHistoryRepository,
-    @Autowired val entityManager: EntityManager,
-    @Autowired val studyHistoryConverter: StudyHistoryConverter
+    private val studyHistoryRepository: StudyHistoryRepository,
+    private val userAccountRepository: UserAccountRepository,
+    private val exerciseRepository: ExerciseRepository,
+    private val studyHistoryConverter: StudyHistoryConverter
 ) {
     private val log = logger()
 
-    fun saveOrUpdateStudyHistory(studyHistoryDto: StudyHistoryDto): StudyHistoryDto {
-        val existingStudyHistory = studyHistoryRepository.findByUserAccountIdAndExerciseId(
-            studyHistoryDto.userId,
-            studyHistoryDto.exerciseId
-        )
-        var isNew = false
-        val studyHistory = existingStudyHistory.map { studyHistoryEntity ->
-            log.debug("Replacing $studyHistoryDto")
-            studyHistoryConverter.updateStudyHistory(studyHistoryDto, studyHistoryEntity)
-            studyHistoryEntity
-        }
-            .orElseGet {
-                log.debug("Saving $studyHistoryDto")
-                val userReference = entityManager.getReference(UserAccount::class.java, studyHistoryDto.userId)
-                val exerciseReference = entityManager.getReference(Exercise::class.java, studyHistoryDto.exerciseId)
-                val studyHistoryEntity = StudyHistory(userAccount = userReference, exercise = exerciseReference)
-                studyHistoryConverter.updateStudyHistory(studyHistoryDto, studyHistoryEntity)
-                isNew = true
-                studyHistoryEntity
-            }
+    fun findBy(userId: Long?, exerciseId: Long?): Optional<StudyHistory> {
+        return studyHistoryRepository.findByUserAccountIdAndExerciseId(userId, exerciseId)
+    }
+
+    fun update(studyHistory: StudyHistory, studyHistoryDto: StudyHistoryDto): StudyHistoryDto {
+        studyHistoryConverter.updateStudyHistory(studyHistoryDto, studyHistory)
         studyHistoryRepository.save(studyHistory)
-        val studyDto = studyHistory.toDto()
-        studyDto.responseCode = if (isNew) HttpStatus.CREATED else HttpStatus.OK
-        return studyDto
+        return studyHistory.toDto()
+    }
+
+    fun create(studyHistoryDto: StudyHistoryDto): StudyHistoryDto {
+        val userAccount = findUserAccount(studyHistoryDto.userId!!)
+        val exercise = findExercise(studyHistoryDto.exerciseId!!)
+
+        val newStudyHistory = StudyHistory(userAccount = userAccount, exercise = exercise)
+        val studyHistory = studyHistoryConverter.updateStudyHistory(studyHistoryDto, newStudyHistory)
+        studyHistoryRepository.save(studyHistory)
+
+        return studyHistory.toDto()
+    }
+
+    private fun findUserAccount(id: Long): UserAccount {
+        return userAccountRepository
+            .findUserAccountById(id)
+            .orElseThrow { EntityNotFoundException("UserAccount with userId '$id' doesn't exist.") }
+    }
+
+    private fun findExercise(exerciseId: Long): Exercise {
+        return exerciseRepository
+            .findById(exerciseId)
+            .orElseThrow {
+                EntityNotFoundException("Exercise with exerciseId '$exerciseId' doesn't exist.")
+            }
     }
 
     @Throws(InvalidParameterException::class)
     fun patchStudyHistory(studyHistoryDto: StudyHistoryDto): StudyHistoryDto {
         log.debug("Patching $studyHistoryDto")
-        return studyHistoryRepository.findByUserAccountIdAndExerciseId(
-            studyHistoryDto.userId,
-            studyHistoryDto.exerciseId
-        ).map { studyHistoryEntity ->
-            studyHistoryConverter.updateStudyHistoryWhereNotNull(studyHistoryDto, studyHistoryEntity)
-            studyHistoryRepository.save(studyHistoryEntity).toDto()
-        }
-            .orElseThrow { EntityNotFoundException("Could not find requested study history with id=${studyHistoryDto.id}") }
+        return studyHistoryRepository
+            .findByUserAccountIdAndExerciseId(
+                studyHistoryDto.userId,
+                studyHistoryDto.exerciseId
+            ).map { studyHistoryEntity ->
+                studyHistoryConverter.updateStudyHistoryWhereNotNull(studyHistoryDto, studyHistoryEntity)
+                studyHistoryRepository.save(studyHistoryEntity).toDto()
+            }.orElseThrow {
+                EntityNotFoundException("Could not find requested study history with id=${studyHistoryDto.id}")
+            }
     }
 }

--- a/src/test/kotlin/com/epam/brn/controller/StudyHistoryControllerTest.kt
+++ b/src/test/kotlin/com/epam/brn/controller/StudyHistoryControllerTest.kt
@@ -1,9 +1,13 @@
 package com.epam.brn.controller
 
 import com.epam.brn.dto.StudyHistoryDto
+import com.epam.brn.model.Exercise
+import com.epam.brn.model.StudyHistory
+import com.epam.brn.model.UserAccount
 import com.epam.brn.service.StudyHistoryService
 import com.nhaarman.mockito_kotlin.verify
 import java.time.LocalDateTime
+import java.util.Optional
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -18,11 +22,12 @@ internal class StudyHistoryControllerTest {
 
     @Mock
     lateinit var studyHistoryService: StudyHistoryService
+
     @InjectMocks
     lateinit var studyHistoryController: StudyHistoryController
 
     @Test
-    fun `should save study history`() {
+    fun `should create new study history`() {
         // GIVEN
         val dto = StudyHistoryDto(
             userId = 1L,
@@ -30,15 +35,52 @@ internal class StudyHistoryControllerTest {
             tasksCount = 1,
             startTime = LocalDateTime.now(),
             endTime = LocalDateTime.now(),
-            exerciseId = 1L,
-            responseCode = HttpStatus.CREATED
+            exerciseId = 1L
         )
-        `when`(studyHistoryService.saveOrUpdateStudyHistory(dto)).thenReturn(dto)
+        `when`(studyHistoryService.findBy(dto.userId, dto.exerciseId)).thenReturn(Optional.empty())
+        `when`(studyHistoryService.create(dto)).thenReturn(dto)
+
         // WHEN
-        val result = studyHistoryController.saveOrUpdateStudyHistory(dto)
+        val result = studyHistoryController.save(dto)
+
         // THEN
-        verify(studyHistoryService).saveOrUpdateStudyHistory(dto)
+        verify(studyHistoryService).create(dto)
         assertEquals(HttpStatus.CREATED, result.statusCode)
+    }
+
+    @Test
+    fun `should update existing study history`() {
+        // GIVEN
+        val dto = StudyHistoryDto(
+            userId = 1L,
+            repetitionIndex = 1f,
+            tasksCount = 1,
+            startTime = LocalDateTime.now(),
+            endTime = LocalDateTime.now(),
+            exerciseId = 1L
+        )
+        val studyHistory = StudyHistory(
+            userAccount = UserAccount(
+                firstName = "testUserFirstName",
+                lastName = "testUserLastName",
+                password = "test",
+                email = "test@gmail.com",
+                active = true
+            ),
+            exercise = Exercise(
+                id = 1L
+            )
+        )
+
+        `when`(studyHistoryService.findBy(dto.userId, dto.exerciseId)).thenReturn(Optional.of(studyHistory))
+        `when`(studyHistoryService.update(studyHistory, dto)).thenReturn(dto)
+
+        // WHEN
+        val result = studyHistoryController.save(dto)
+
+        // THEN
+        verify(studyHistoryService).update(studyHistory, dto)
+        assertEquals(HttpStatus.OK, result.statusCode)
     }
 
     @Test

--- a/src/test/kotlin/com/epam/brn/service/StudyHistoryServiceTest.kt
+++ b/src/test/kotlin/com/epam/brn/service/StudyHistoryServiceTest.kt
@@ -5,62 +5,88 @@ import com.epam.brn.dto.StudyHistoryDto
 import com.epam.brn.model.Exercise
 import com.epam.brn.model.StudyHistory
 import com.epam.brn.model.UserAccount
+import com.epam.brn.repo.ExerciseRepository
 import com.epam.brn.repo.StudyHistoryRepository
+import com.epam.brn.repo.UserAccountRepository
+import com.nhaarman.mockito_kotlin.anyOrNull
 import com.nhaarman.mockito_kotlin.doNothing
+import com.nhaarman.mockito_kotlin.eq
 import com.nhaarman.mockito_kotlin.verify
 import java.time.LocalDateTime
 import java.util.Optional
-import javax.persistence.EntityManager
-import kotlin.test.assertEquals
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.ArgumentMatchers.any
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.Mockito.`when`
+import org.mockito.Mockito.any
 import org.mockito.junit.jupiter.MockitoExtension
-import org.springframework.http.HttpStatus
 
 @ExtendWith(MockitoExtension::class)
 internal class StudyHistoryServiceTest {
 
     @Mock
-    lateinit var entityManager: EntityManager
+    lateinit var userAccountRepository: UserAccountRepository
+
+    @Mock
+    lateinit var exerciseRepository: ExerciseRepository
+
     @Mock
     lateinit var studyHistoryRepository: StudyHistoryRepository
+
     @Mock
     lateinit var studyHistoryConverter: StudyHistoryConverter
+
     @InjectMocks
     lateinit var studyHistoryService: StudyHistoryService
 
     @Test
-    fun `should create studyHistory when doesnt exist`() {
+    fun `should create studyHistory when doesn't exist`() {
         // GIVEN
+        val now = LocalDateTime.now()
+
         val dto = StudyHistoryDto(
             userId = 1L,
             repetitionIndex = 1f,
             tasksCount = 1,
-            startTime = LocalDateTime.now(),
-            endTime = LocalDateTime.now(),
+            startTime = now,
+            endTime = now,
             exerciseId = 1L
         )
-        val exerciseMock = Mockito.mock(Exercise::class.java)
-        val userAccountMock = Mockito.mock(UserAccount::class.java)
-        val studyHistoryEntity = StudyHistory(
-            userAccount = userAccountMock,
-            exercise = exerciseMock
+        val userAccount = UserAccount(
+            id = 1L,
+            firstName = "testUserFirstName",
+            lastName = "testUserLastName",
+            password = "test",
+            email = "test@gmail.com",
+            active = true
         )
-        `when`(entityManager.getReference(UserAccount::class.java, dto.userId)).thenReturn(userAccountMock)
-        `when`(entityManager.getReference(Exercise::class.java, dto.exerciseId)).thenReturn(exerciseMock)
-        `when`(
-            studyHistoryRepository.findByUserAccountIdAndExerciseId(dto.userId, dto.exerciseId)
-        ).thenReturn(Optional.empty())
+        val exercise = Exercise(
+            id = 1L
+        )
+        val studyHistoryEntity = StudyHistory(
+            id = 1L,
+            userAccount = userAccount,
+            exercise = exercise,
+            startTime = now,
+            endTime = now,
+            tasksCount = 1,
+            repetitionIndex = 1f
+        )
+
+        `when`(userAccountRepository.findUserAccountById(dto.userId!!)).thenReturn(Optional.of(userAccount))
+        `when`(exerciseRepository.findById(dto.exerciseId!!)).thenReturn(Optional.of(exercise))
+        `when`(studyHistoryConverter.updateStudyHistory(eq(dto), anyOrNull()))
+            .thenReturn(studyHistoryEntity)
+
         // WHEN
-        val result = studyHistoryService.saveOrUpdateStudyHistory(dto)
+        val result = studyHistoryService.create(dto)
+
         // THEN
-        assertEquals(HttpStatus.CREATED, result.responseCode)
-        verify(studyHistoryConverter).updateStudyHistory(dto, studyHistoryEntity)
+        assertThat(result).isEqualToIgnoringGivenFields(dto, "id")
+        verify(studyHistoryConverter).updateStudyHistory(eq(dto), anyOrNull())
         verify(studyHistoryRepository).save(any(StudyHistory::class.java))
     }
 
@@ -75,16 +101,15 @@ internal class StudyHistoryServiceTest {
             endTime = LocalDateTime.now(),
             exerciseId = 1L
         )
-        val existingStudyHistoryEntity = Mockito.mock(StudyHistory::class.java)
-        `when`(existingStudyHistoryEntity.toDto()).thenReturn(dto)
-        `when`(
-            studyHistoryRepository.findByUserAccountIdAndExerciseId(dto.userId, dto.exerciseId)
-        ).thenReturn(Optional.of(existingStudyHistoryEntity))
+        val existingStudyHistory = Mockito.mock(StudyHistory::class.java)
+
+        `when`(existingStudyHistory.toDto()).thenReturn(dto)
+
         // WHEN
-        val result = studyHistoryService.saveOrUpdateStudyHistory(dto)
+        studyHistoryService.update(existingStudyHistory, dto)
+
         // THEN
-        assertEquals(HttpStatus.OK, result.responseCode)
-        verify(studyHistoryConverter).updateStudyHistory(dto, existingStudyHistoryEntity)
+        verify(studyHistoryConverter).updateStudyHistory(dto, existingStudyHistory)
         verify(studyHistoryRepository).save(any(StudyHistory::class.java))
     }
 
@@ -120,10 +145,12 @@ internal class StudyHistoryServiceTest {
             repetitionIndex = 1f
         )
         `when`(studyHistoryRepository.save(any(StudyHistory::class.java))).thenReturn(updatedEntity)
+
         doNothing().`when`(studyHistoryConverter).updateStudyHistoryWhereNotNull(dto, existingEntity)
-        `when`(
-            studyHistoryRepository.findByUserAccountIdAndExerciseId(dto.userId, dto.exerciseId)
-        ).thenReturn(Optional.of(existingEntity))
+
+        `when`(studyHistoryRepository.findByUserAccountIdAndExerciseId(dto.userId, dto.exerciseId))
+            .thenReturn(Optional.of(existingEntity))
+
         // WHEN
         studyHistoryService.patchStudyHistory(dto)
         // THEN


### PR DESCRIPTION
[EPMLABSBRN-221](https://jira.epam.com/jira/browse/EPMLABSBRN-221)

500 error was returned because of DB constraint violation. That happened because of missing non-existing dependent entities check, like Exercise and UserAccount. Now if wrong ids are passed and no entities were found correct exception is thrown.
