### PR TITLE
EPMLABSBRN-430: removing email from message

### DIFF
--- a/api-contract/samples/authSuchUserAlreadyExistErrorResponse.json
+++ b/api-contract/samples/authSuchUserAlreadyExistErrorResponse.json
@@ -1,7 +1,7 @@
 {
   "data": [],
   "errors": [
-    "User with email admin@admin.com is already exist!"
+    "The user already exists!"
   ],
   "meta": []
 }

--- a/src/main/kotlin/com/epam/brn/service/impl/UserAccountServiceImpl.kt
+++ b/src/main/kotlin/com/epam/brn/service/impl/UserAccountServiceImpl.kt
@@ -39,7 +39,7 @@ class UserAccountServiceImpl(
     override fun addUser(userAccountDto: UserAccountDto): UserAccountDto {
         val existUser = userAccountRepository.findUserAccountByEmail(userAccountDto.email)
         existUser.ifPresent {
-            throw IllegalArgumentException("User with email ${userAccountDto.email} is already exist!")
+            throw IllegalArgumentException("The user already exists!")
         }
 
         val setOfAuthorities = getTheAuthoritySet(userAccountDto)


### PR DESCRIPTION
[EPMLABSBRN-430](https://jira.epam.com/jira/browse/EPMLABSBRN-430)

**Current state**:
 we send emails in the body of error message. We have to remove it from the message. Example:
`User with email admin@admin.com already exists!`

**After fix**:
`The user already exists`