### PR TITLE
Epmlabsbrn-497 [Demo] add multilanguage support for grous

### DIFF
--- a/src/main/kotlin/com/epam/brn/config/WebMvcBasicConfiguration.kt
+++ b/src/main/kotlin/com/epam/brn/config/WebMvcBasicConfiguration.kt
@@ -1,0 +1,25 @@
+package com.epam.brn.config
+
+import java.util.Locale
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.LocaleResolver
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+import org.springframework.web.servlet.i18n.LocaleChangeInterceptor
+import org.springframework.web.servlet.i18n.SessionLocaleResolver
+
+@Configuration
+class WebMvcBasicConfiguration : WebMvcConfigurer {
+
+    @Bean
+    fun localeResolver(): LocaleResolver {
+        val slr = SessionLocaleResolver()
+        slr.setDefaultLocale(Locale("ru", "RU"))
+        return slr
+    }
+
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addInterceptor(LocaleChangeInterceptor())
+    }
+}

--- a/src/main/kotlin/com/epam/brn/controller/GroupController.kt
+++ b/src/main/kotlin/com/epam/brn/controller/GroupController.kt
@@ -2,10 +2,11 @@ package com.epam.brn.controller
 
 import com.epam.brn.dto.BaseResponseDto
 import com.epam.brn.dto.BaseSingleObjectResponseDto
+import com.epam.brn.dto.ExerciseGroupDto
 import com.epam.brn.service.ExerciseGroupsService
+import com.epam.brn.service.LocalePostprocessor
 import io.swagger.annotations.Api
 import io.swagger.annotations.ApiOperation
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -15,14 +16,16 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/groups")
 @Api(value = "/groups", description = "Contains actions over groups")
-class GroupController(@Autowired val exerciseGroupsService: ExerciseGroupsService) {
+class GroupController(val exerciseGroupsService: ExerciseGroupsService, val localePostProcessor: LocalePostprocessor<ExerciseGroupDto>) {
 
     // The discrepancy in naming with "Groups" endpoint and "ExerciseGroup" entity is due to
     // group being a reserved word in db.
     @GetMapping
     @ApiOperation("Get all groups")
     fun getAllGroups(): ResponseEntity<BaseResponseDto> {
-        return ResponseEntity.ok().body(BaseResponseDto(data = exerciseGroupsService.findAllGroups()))
+        val data = exerciseGroupsService.findAllGroups()
+            .map { localePostProcessor.postprocess(it) }
+        return ResponseEntity.ok().body(BaseResponseDto(data = data))
     }
 
     @GetMapping(value = ["/{groupId}"])

--- a/src/main/kotlin/com/epam/brn/dto/ExerciseGroupDto.kt
+++ b/src/main/kotlin/com/epam/brn/dto/ExerciseGroupDto.kt
@@ -5,8 +5,8 @@ import javax.validation.constraints.NotBlank
 data class ExerciseGroupDto(
     val id: Long?,
     @NotBlank
-    val name: String?,
-    val description: String?,
+    var name: String?,
+    var description: String?,
     val series: MutableSet<Long?> = HashSet()
 ) {
     constructor() : this(null, null, null)

--- a/src/main/kotlin/com/epam/brn/service/GroupLocalePostprocessorImpl.kt
+++ b/src/main/kotlin/com/epam/brn/service/GroupLocalePostprocessorImpl.kt
@@ -1,0 +1,27 @@
+package com.epam.brn.service
+
+import com.epam.brn.dto.ExerciseGroupDto
+import org.springframework.context.MessageSource
+import org.springframework.context.i18n.LocaleContextHolder
+import org.springframework.stereotype.Component
+
+@Component
+class GroupLocalePostprocessorImpl(private val messageSource: MessageSource) : LocalePostprocessor<ExerciseGroupDto> {
+
+    private val mapOfMessages: Map<String, Pair<String, String>> = mapOf(
+        "Неречевые упражнения" to Pair("group.first.name", "group.first.description"),
+        "Речевые упражнения" to Pair("group.second.name", "group.second.description")
+    )
+
+    override fun postprocess(dto: ExerciseGroupDto): ExerciseGroupDto {
+        val sourceName = mapOfMessages[dto.name]
+        sourceName?.let {
+            val locale = LocaleContextHolder.getLocale()
+            val name = messageSource.getMessage(it.first, null, locale)
+            val description = messageSource.getMessage(it.second, null, locale)
+            dto.name = name
+            dto.description = description
+        }
+        return dto
+    }
+}

--- a/src/main/kotlin/com/epam/brn/service/LocalePostprocessor.kt
+++ b/src/main/kotlin/com/epam/brn/service/LocalePostprocessor.kt
@@ -1,0 +1,5 @@
+package com.epam.brn.service
+
+interface LocalePostprocessor<Dto> {
+    fun postprocess(dto: Dto): Dto
+}

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,0 +1,4 @@
+group.first.name=Неречевые упражнения
+group.second.name=Речевые упражнения
+group.first.description=Неречевые упражнения
+group.second.description=Речевые упражнения

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -1,0 +1,4 @@
+group.first.name=non-speech exercises
+group.second.name=speech exercises
+group.first.description=non-speech exercises
+group.second.description=speech exercises

--- a/src/main/resources/messages_ru.properties
+++ b/src/main/resources/messages_ru.properties
@@ -1,0 +1,4 @@
+group.first.name=Неречевые упражнения
+group.second.name=Речевые упражнения
+group.first.description=Неречевые упражнения
+group.second.description=Речевые упражнения

--- a/src/test/kotlin/com/epam/brn/controller/GroupControllerTest.kt
+++ b/src/test/kotlin/com/epam/brn/controller/GroupControllerTest.kt
@@ -2,6 +2,7 @@ package com.epam.brn.controller
 
 import com.epam.brn.dto.ExerciseGroupDto
 import com.epam.brn.service.ExerciseGroupsService
+import com.epam.brn.service.LocalePostprocessor
 import com.nhaarman.mockito_kotlin.verify
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -16,6 +17,8 @@ import org.mockito.junit.jupiter.MockitoExtension
 internal class GroupControllerTest {
     @Mock
     lateinit var exerciseGroupsService: ExerciseGroupsService
+    @Mock
+    lateinit var localePostProcessor: LocalePostprocessor<ExerciseGroupDto>
     @InjectMocks
     lateinit var groupController: GroupController
 
@@ -25,6 +28,7 @@ internal class GroupControllerTest {
         val group = ExerciseGroupDto(1, "name", "desc")
         val listGroups = listOf(group)
         Mockito.`when`(exerciseGroupsService.findAllGroups()).thenReturn(listGroups)
+        Mockito.`when`(localePostProcessor.postprocess(group)).thenReturn(group)
         // WHEN
         @Suppress("UNCHECKED_CAST")
         val actualResultData: List<ExerciseGroupDto> =
@@ -40,6 +44,7 @@ internal class GroupControllerTest {
         val groupId = 1L
         val group = ExerciseGroupDto(1, "name", "desc")
         Mockito.`when`(exerciseGroupsService.findGroupDtoById(groupId)).thenReturn(group)
+
         // WHEN
         val actualResultData: ExerciseGroupDto =
             groupController.getGroupById(groupId).body?.data as ExerciseGroupDto


### PR DESCRIPTION
[EPMLABSBRN-497](https://jira.epam.com/jira/browse/EPMLABSBRN-497)

**Internalization was implemented for requests to get exercise groups**

For implementation was used a map to store the mapping:
- group name (unique) **to** messages

This solution includes a common spring approach, but the other part is temporary and to implement full internalization flow, translate of elements should be added initially by an operator and saved to the database or translate should be used from messages.properties

Examples:

- api/groups?locale=en_EN

![image](https://user-images.githubusercontent.com/17047484/83969776-866f4f00-a8da-11ea-94b9-e73a87084b78.png)

- api/groups?locale=ru_RU

![image](https://user-images.githubusercontent.com/17047484/83969786-95560180-a8da-11ea-863b-609bbda8d2e2.png)
