### PR TITLE
EPMLABSBRN-582 Change the NoiseDto's fields names

### DIFF
--- a/src/main/kotlin/com/epam/brn/dto/NoiseDto.kt
+++ b/src/main/kotlin/com/epam/brn/dto/NoiseDto.kt
@@ -1,6 +1,6 @@
 package com.epam.brn.dto
 
 data class NoiseDto(
-    var noiseLevel: Int = 0,
-    var noiseUrl: String? = null
+    var level: Int = 0,
+    var url: String? = null
 )


### PR DESCRIPTION
[EPMLABSBRN-582](https://jira.epam.com/jira/browse/EPMLABSBRN-582)

Change the NoiseDto's fields names

NoiseDto should have the body with the following fields :

`data class NoiseDto(
var level: Int = 0,
var url: String? = null
)
`