### PR TITLE
Added GITHUB_TOKEN to env variables for sonarcloud integration

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -20,3 +20,5 @@ jobs:
           java-version: 11
       - name: Build, Unit and Integration Tests
         run: ./gradlew build test integrationTest jacocoTestReport sonarqube
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fix of issue from 
https://github.com/Brain-up/brn/runs/1588229328
> Please add the secret GITHUB_TOKEN as an environment variable to your GitHub Actions workflow. See https://github.com/sonarsource/sonarcloud-github-action for more details.

