### PR TITLE
[frontend] 2023: Description & locale buttons are transparent if user is not logged in

### DIFF
--- a/frontend/app/components/header/component.ts
+++ b/frontend/app/components/header/component.ts
@@ -8,6 +8,10 @@ export default class HeaderComponent extends Component {
   @service('session') session!: Session;
   @service('user-data') userData!: UserDataService;
 
+  get activeLocale() {
+    return this.userData.activeLocale;
+  }
+
   get avatarUrl() {
     return this.userData.avatarUrl;
   }

--- a/frontend/app/components/header/template.hbs
+++ b/frontend/app/components/header/template.hbs
@@ -29,7 +29,14 @@
     <div
       class="lg:flex lg:items-center lg:w-auto relative z-10 flex-grow block"
     >
-      <div class="lg:flex-grow text-xs text-white">
+      <div
+        class="lg:flex-grow text-xs
+          {{if
+            this.session.isAuthenticated
+            "text-white"
+            "text-purple-primary"
+          }}"
+      >
         {{#if this.session.isAuthenticated}}
           <LinkTo
             @route="groups"
@@ -42,15 +49,24 @@
         {{/if}}
         <LinkTo
           @route="description"
-          class="lg:inline-block lg:mt-0 hover:bg-white hover:text-purple-primary block px-4 py-2 mt-4 mr-4 font-bold tracking-wider text-white uppercase rounded-full"
+          class="lg:inline-block lg:mt-0 block px-4 py-2 mt-4 mr-4 font-bold tracking-wider uppercase rounded-full
+            {{if
+              this.session.isAuthenticated
+              "hover:bg-white hover:text-purple-primary"
+              "hover:bg-purple-primary hover:text-white"
+            }}"
         >
           {{t "header.about"}}
         </LinkTo>
         <button
           type="button"
-          class="hover:text-opacity-50 text-white py-2 bg-transparent rounded uppercase
+          class="hover:text-opacity-50 py-2 bg-transparent rounded uppercase
             {{if (eq this.activeLocale "ru-ru") "font-bold"}}
-            "
+            {{if
+              this.session.isAuthenticated
+              "text-white"
+              "text-purple-primary"
+            }}"
           {{on "click" (fn this.setLocale "ru")}}
         >
           RU
@@ -58,8 +74,13 @@
         /
         <button
           type="button"
-          class="hover:text-opacity-50 text-white py-2 bg-transparent rounded uppercase
-            {{if (eq this.activeLocale "en-us") "font-bold"}}"
+          class="hover:text-opacity-50 py-2 bg-transparent rounded uppercase
+            {{if (eq this.activeLocale "en-us") "font-bold"}}
+            {{if
+              this.session.isAuthenticated
+              "text-white"
+              "text-purple-primary"
+            }}"
           {{on "click" (fn this.setLocale "en")}}
         >
           EN

--- a/frontend/tests/integration/components/header/component-test.js
+++ b/frontend/tests/integration/components/header/component-test.js
@@ -15,11 +15,13 @@ module('Integration | Component | header', function (hooks) {
     await authenticateSession();
     await render(hbs`<Header />`);
 
-    assert.dom('[data-test-group-link]').hasAttribute('href', '/groups');
+    assert
+      .dom('[data-test-group-link]')
+      .hasAttribute('href', /^\/groups\?locale=(?:en-us|ru-ru)$/);
     assert.dom('[data-test-logo]').hasAttribute('href', '/');
   });
 
-  test('it not render group link if user not authorized', async function (assert) {
+  test('it does not render group link if user is not authorized', async function (assert) {
     this.owner.setupRouter();
     await invalidateSession();
     await render(hbs`<Header />`);


### PR DESCRIPTION
+ getter activeLocale added into the header component

#2023 