### PR TITLE
Disable epam instance deploy because of dockerhub pull limits in epam network

### DIFF
--- a/.github/workflows/docker-build-push-redeploy.yml
+++ b/.github/workflows/docker-build-push-redeploy.yml
@@ -43,7 +43,8 @@ jobs:
     runs-on: ${{ matrix.runners }}
     strategy:
       matrix:
-        runners: [ epam, vscale ]
+        # runners: [ epam, vscale ]
+        runners: [ vscale ]
     steps:
       - uses: actions/checkout@master
       - name: Configure secrets


### PR DESCRIPTION
We have errors during requests to download images from dockerhub such as:
```
ERROR: for brn  toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
```
like here: https://github.com/Brain-up/brn/runs/2977823066

To mitigate the issue, I temporarly disabled deploy for epam instance.

But in the future, possible solution is move out from dockerhub to some other docker registry, for example github packages https://github.com/features/packages