### PR TITLE
[EPMLABSBRN-887] [DevOps] Save cicd artifacts such integration test reports for ability to see them

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -19,3 +19,15 @@ jobs:
         run: ./gradlew build test integrationTest jacocoTestReport sonarqube
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload Unit Test Results
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: Unit Test Results
+          path: build/reports/tests/test/
+      - name: Upload Integration Test Results
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: Integration Test Results
+          path: build/reports/tests/integrationTest/

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ brn.log.*
 
 ### OS generated files ###
 .DS_Store
+
+### Kotlin tests
+words_en.txt
+words_ru.txt


### PR DESCRIPTION
[EPMLABSBRN-887](https://jira.epam.com/jira/browse/EPMLABSBRN-887)

**Description**:
Save cicd artifacts such integration test reports for ability to see them

as now MR falls

https://github.com/Brain-up/brn/pull/2031

and we can't see such reports