### PR TITLE
EPMLABSBRN-493 update log4j-api-kotlin 1.0.0 -> 1.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-csv"
 
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2'
-    implementation "org.apache.logging.log4j:log4j-api-kotlin:1.0.0"
+    implementation "org.apache.logging.log4j:log4j-api-kotlin:$log4jApiKotlinVersion"
 
     implementation "io.springfox:springfox-swagger-ui:2.10.5"
     implementation "io.springfox:springfox-swagger2:2.9.2"

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,5 +8,6 @@ junitVersion=5.3.1
 mockkVersion=1.12.0
 kotestAssertionsVerstion=4.0.7
 jsonVersoin=20210307
+log4jApiKotlinVersion=1.1.0
 
 testContainersVersion=1.15.1


### PR DESCRIPTION
this should fix CVE-2020-9488 Improper Certificate Validation

[EPMLABSBRN-XX](https://jira.epam.com/jira/browse/EPMLABSBRN-XX)

**Description**:
