### PR TITLE
EPMLABSBRN-908 BE: Change jcenter() to mavenCentral()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ allOpen {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {
@@ -46,10 +46,10 @@ dependencies {
     implementation 'com.amazonaws:aws-java-sdk:1.11.808'
     implementation 'com.google.cloud:google-cloud-storage:1.110.0'
 
-    implementation 'khttp:khttp:1.0.0'
+    implementation "org.json:json:$jsonVersoin"
     implementation 'net.bramp.ffmpeg:ffmpeg:0.6.2'
 
-    testImplementation 'org.amshove.kluent:kluent:1.61' //should be deleted after kotest move all of it
+    testImplementation 'org.amshove.kluent:kluent:1.68' //should be deleted after kotest move all of it
     testImplementation "org.jetbrains.kotlin:kotlin-test:1.3.72" //should be deleted after kotest move all of it
     testImplementation "io.kotest:kotest-assertions:$kotestAssertionsVerstion"
     testImplementation "io.kotest:kotest-assertions-core:$kotestAssertionsVerstion"

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,6 @@ flywayVersion=6.5.5
 junitVersion=5.3.1
 mockkVersion=1.12.0
 kotestAssertionsVerstion=4.0.7
+jsonVersoin=20210307
 
 testContainersVersion=1.15.1


### PR DESCRIPTION
Builds will no longer be able to resolve artifacts from JCenter after February 1st, 2022