### PR TITLE
fix: typo in header

### DIFF
--- a/frontend/translations/en-us.yaml
+++ b/frontend/translations/en-us.yaml
@@ -6,7 +6,7 @@ header:
   more: More...
   donate: Donate
   github: GitHub
-  contact: Contact
+  contact: Contacts
   info: Info
   used_resources: Used Resources
   specialists: Specialists


### PR DESCRIPTION
##2516
[Bug] A typo in the name of the "Contacts" section in the navbar menu in English version

Fix:
Changed the 'Contact' spelling to   'Contacts' in the header.
