### PR TITLE
fix: only numbers allowed in year of birth

### DIFF
--- a/frontend/app/components/profile/component.ts
+++ b/frontend/app/components/profile/component.ts
@@ -117,4 +117,21 @@ export default class ProfileComponent extends Component {
       });
     }
   }
+
+  @action 
+  setBirthday(e: Event) {
+      const key = e.key;
+      const allowedKeys = [
+        'Backspace',
+        'Delete',
+        'Tab',
+        'Enter',
+        'ArrowLeft',
+        'ArrowRight',
+      ];
+      const isValid = allowedKeys.includes(key) || !isNaN(key as any);
+      if (!isValid) {
+        e.preventDefault();
+      }
+  }
 }

--- a/frontend/app/components/profile/template.hbs
+++ b/frontend/app/components/profile/template.hbs
@@ -50,6 +50,7 @@
         minlength="4"
         maxlength="4"
         pattern="[0-9]{4}"
+        {{on "keydown" this.setBirthday}}
         {{on "change" (fn this.onInput "birthday")}}
         @warning={{this.warningErrorDate}}
         @model={{this.user}}

--- a/frontend/app/components/registration-form/component.ts
+++ b/frontend/app/components/registration-form/component.ts
@@ -151,4 +151,22 @@ export default class RegistrationFormComponent extends LoginFormComponent {
   setAgreedStatus(e: Document & any) {
     this.agreed = e.target.checked;
   }
+
+  @action
+  setBirthday(e: Event) {
+    const key = e.key;
+    const allowedKeys = [
+      'Backspace',
+      'Delete',
+      'Tab',
+      'Enter',
+      'ArrowLeft',
+      'ArrowRight',
+    ];
+    const isValid = allowedKeys.includes(key) || !isNaN(key as any);
+    if (!isValid) {
+      e.preventDefault();
+    }  
+    
+  }
 }

--- a/frontend/app/components/registration-form/template.hbs
+++ b/frontend/app/components/registration-form/template.hbs
@@ -42,6 +42,7 @@
           @placeholder={{t "registration_form.birthday_placeholder"}}
           @model={{this}}
           @name="birthday"
+          {{on "keydown" this.setBirthday}}
         />
       </div>
       <div class="mb-4">


### PR DESCRIPTION
##2474

**Description what actually was done in task**:
I added a keydown method to only accept numeric values for the year of birth input on both the registration and profile pages.