### PR TITLE
Update actions/checkout to v4

### DIFF
--- a/.github/workflows/certbot-update-cert.yml
+++ b/.github/workflows/certbot-update-cert.yml
@@ -8,7 +8,7 @@ jobs:
   update_certs:
     runs-on: vscale
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Configure secrets
         run: |
           echo "$S3_KEY"|base64 -d > aws-key.properties

--- a/.github/workflows/create_cert.yml
+++ b/.github/workflows/create_cert.yml
@@ -5,7 +5,7 @@ jobs:
   update_certs:
     runs-on: vscale
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Configure secrets
         run: |
           echo "$S3_KEY"|base64 -d > aws-key.properties

--- a/.github/workflows/docker-build-push-redeploy.yml
+++ b/.github/workflows/docker-build-push-redeploy.yml
@@ -9,7 +9,7 @@ jobs:
   build_and_publish_backend:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Publish to Registry brainup/brn-backend
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
@@ -19,7 +19,7 @@ jobs:
   build_and_publish_frontend:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Publish to Registry brainup/brn-frontend
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
@@ -30,7 +30,7 @@ jobs:
   build_and_publish_frontend_with_tls:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Publish to Registry brainup/brn-frontend-with-tls
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
@@ -46,7 +46,7 @@ jobs:
         # runners: [ epam, vscale ]
         runners: [ vscale ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Configure secrets
         run: |
           echo "$S3_KEY"|base64 -d > aws-key.properties

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,7 +6,7 @@ jobs:
   build_backend:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build the Docker image for backend
       run: docker build . --file Dockerfile --tag brainup/brn-backend
     - name: List of docker images
@@ -14,7 +14,7 @@ jobs:
   build_frontend:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build the Docker image for frontent
       run: docker build . --file Dockerfile_frontend --tag brainup/brn-frontend
     - name: List of docker images

--- a/.github/workflows/fe-admin-composition-analysis.yml
+++ b/.github/workflows/fe-admin-composition-analysis.yml
@@ -21,7 +21,7 @@ jobs:
     name: npm audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2-beta
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: rwjblue/setup-volta@v1

--- a/.github/workflows/fe-app-composition-analysis.yml
+++ b/.github/workflows/fe-app-composition-analysis.yml
@@ -21,7 +21,7 @@ jobs:
     name: yarn audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2-beta
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: rwjblue/setup-volta@v1

--- a/.github/workflows/frontend-admin.yml
+++ b/.github/workflows/frontend-admin.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run action checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         working-directory: ./frontend-angular
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run action checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Install Chrome
         run: |
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run action checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         working-directory: ./frontend-angular

--- a/.github/workflows/frontend-app-test.yml
+++ b/.github/workflows/frontend-app-test.yml
@@ -7,7 +7,7 @@ jobs:
     name: Frontend tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: rwjblue/setup-volta@v1
       - uses: H1D/actions-ember-testing@8ca8da615c2db5889b7fbd3834e4093706754435
       - name: Install dependencies
@@ -30,7 +30,7 @@ jobs:
     name: Test coverage changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - uses: rwjblue/setup-volta@v1
       - uses: H1D/actions-ember-testing@8ca8da615c2db5889b7fbd3834e4093706754435
       - name: Install dependencies
@@ -48,7 +48,7 @@ jobs:
 #    name: App build
 #    runs-on: ubuntu-latest
 #    steps:
-#      - uses: actions/checkout@v2-beta
+#      - uses: actions/checkout@v4
 #        with:
 #          fetch-depth: 0
 #      - name: Change dir to frontend

--- a/.github/workflows/instances-redeploy.yml_tmp
+++ b/.github/workflows/instances-redeploy.yml_tmp
@@ -12,7 +12,7 @@ jobs:
       matrix:
         runners: [ epam, vscale ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Configure secrets
         run: |
           echo "$S3_KEY"|base64 -d > aws-key.properties

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:


### PR DESCRIPTION
No task number

**Description what actually was done in task**:
- updated actions/checkout version to v4. to fix issue with deprecated node version which we can see in pipelines.

actions/checkout changelog can be found here: https://github.com/actions/checkout/blob/main/CHANGELOG.md
and update node here: https://github.com/actions/checkout/blob/main/CHANGELOG.md#v400