### PR TITLE
Remove separate frontend image from building process

### DIFF
--- a/.github/workflows/docker-build-push-redeploy.yml
+++ b/.github/workflows/docker-build-push-redeploy.yml
@@ -16,17 +16,6 @@ jobs:
         name: brainup/brn-backend
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-  build_and_publish_frontend:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - name: Publish to Registry brainup/brn-frontend
-      uses: elgohr/Publish-Docker-Github-Action@master
-      with:
-        name: brainup/brn-frontend
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        dockerfile: Dockerfile_frontend
   build_and_publish_frontend_with_tls:
     runs-on: ubuntu-latest
     steps:
@@ -39,7 +28,7 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         dockerfile: Dockerfile_frontend_with_tls
   redeploy_instance:
-    needs: [ build_and_publish_backend, build_and_publish_frontend, build_and_publish_frontend_with_tls]
+    needs: [ build_and_publish_backend, build_and_publish_frontend_with_tls]
     runs-on: ${{ matrix.runners }}
     strategy:
       matrix:


### PR DESCRIPTION
##GithubTaskNumber

**Description what actually was done in task**:
Right now we have two images for frontend app - one with tls and one without. Right now without tls not used. So to reduce time of building on master branch, I've decided to remove building frontend app without tls, as it is not used anymore after removal of epam instance