### PR TITLE
Issue 2684 remove dependencies for mockito and powermock (mockito is …

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -90,8 +90,6 @@ dependencies {
     testImplementation("io.mockk:mockk:$mockkVersion")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
     testImplementation("org.junit.jupiter:junit-jupiter-params:$junitVersion")
-    testImplementation("org.mockito.kotlin:mockito-kotlin:4.0.0")
-    testImplementation("org.powermock:powermock-mockito-release-full:1.5.4")
 
     testImplementation("org.testcontainers:testcontainers")
     testImplementation("com.natpryce:hamkrest:1.8.0.1")


### PR DESCRIPTION
Removed mockito and powermock dependencies (mockito is still present as transitive through [spring test](org.springframework.boot:spring-boot-starter-test -> 2.5.9), but never used in code imports)

##2684

[BE] Switch on one unit test framework: io.mockk or org.mockito.kotlin

make some investigation of what better to use .
now we use in unit test both, but the idea is to choose one on of them and rewrite tests, that use another.
