### PR TITLE
Fix per-word correctness validation in sentence exercises (#2718)

### DIFF
--- a/frontend/app/components/task-player/words-sequences/component.ts
+++ b/frontend/app/components/task-player/words-sequences/component.ts
@@ -45,6 +45,7 @@ export default class WordsSequencesComponent<
   @tracked tasksCopy: TaskItem[] = [];
   @tracked currentAnswerObject: null | Record<string, string | null> = null;
   @tracked isCorrect = false;
+  @tracked correctnessPerType: Record<string, boolean> = {};
   get task(): T {
     return this.args.task;
   }
@@ -104,6 +105,7 @@ export default class WordsSequencesComponent<
   }
   startTask() {
     this.isCorrect = false;
+    this.correctnessPerType = {};
     this.currentAnswerObject = getEmptyTemplate(this.task.selectedItemsOrder);
     if (this.mode === MODES.TASK) {
       this.audio.startPlayTask(this.audioFiles);
@@ -137,13 +139,18 @@ export default class WordsSequencesComponent<
       [selected.wordType]: selected.word,
     };
     if (this.answerCompleted) {
-      const isCorrect = deepEqual(
-        this.task.selectedItemsOrder.map(
-          (orderName: string) =>
-            (this.currentAnswerObject as any)[orderName] as string,
-        ),
-        this.firstUncompletedTask?.answer.mapBy('word'),
+      const correctAnswerWords = this.firstUncompletedTask?.answer.mapBy('word') || [];
+      const userAnswerWords = this.task.selectedItemsOrder.map(
+        (orderName: string) =>
+          (this.currentAnswerObject as any)[orderName] as string,
       );
+      const isCorrect = deepEqual(userAnswerWords, correctAnswerWords);
+
+      const correctnessPerType: Record<string, boolean> = {};
+      this.task.selectedItemsOrder.forEach((orderName: string, index: number) => {
+        correctnessPerType[orderName] = userAnswerWords[index] === correctAnswerWords[index];
+      });
+      this.correctnessPerType = correctnessPerType;
 
       this.isCorrect = isCorrect;
 

--- a/frontend/app/components/task-player/words-sequences/template.hbs
+++ b/frontend/app/components/task-player/words-sequences/template.hbs
@@ -16,7 +16,7 @@
             {{#each (get @task.answerOptions type) as |answerOption|}}
               <TextImageButton
                 @checked={{this.answerCompleted}}
-                @isCorrect={{this.isCorrect}}
+                @isCorrect={{get this.correctnessPerType type}}
                 @disabled={{@disableAnswers}}
                 @isSelected={{or
                   (eq @activeWord answerOption.word)

--- a/frontend/tests/integration/components/task-player/words-sequences/component-test.js
+++ b/frontend/tests/integration/components/task-player/words-sequences/component-test.js
@@ -1,9 +1,10 @@
 import { module, test } from 'qunit';
 import { setupIntl } from 'ember-intl/test-support';import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, click, settled, waitFor } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import data from './test-support/data-storage';
 import pageObject from './test-support/page-object';
+import AudioService from 'brn/services/audio';
 
 module('Integration | Component | words-seq-task-player', function (hooks) {
   setupRenderingTest(hooks);setupIntl(hooks, 'en-us');
@@ -31,5 +32,88 @@ module('Integration | Component | words-seq-task-player', function (hooks) {
       .forEach((word) => {
         assert.ok(pageWords.includes(word), `word "${word}" is present`);
       });
+  });
+});
+
+module('Integration | Component | words-seq-task-player | per-word correctness', function (hooks) {
+  setupRenderingTest(hooks);setupIntl(hooks, 'en-us');
+
+  hooks.beforeEach(async function () {
+    class MockAudio extends AudioService {
+      startPlayTask() {}
+      audioUrlForText() { return ''; }
+    }
+    this.owner.register('service:audio', MockAudio);
+
+    const store = this.owner.lookup('service:store');
+    const model = store.createRecord('task/words-sequences');
+    model.setProperties({
+      exerciseMechanism: 'MATRIX',
+      type: 'task/MATRIX',
+      name: '',
+      wrongAnswers: [],
+      template: '<OBJECT OBJECT_ACTION>',
+      answerOptions: {
+        OBJECT_ACTION: [
+          { id: 345, audioFileUrl: '', word: 'линь', wordType: 'OBJECT_ACTION', pictureFileUrl: '', soundsCount: 0 },
+          { id: 346, audioFileUrl: '', word: 'бал', wordType: 'OBJECT_ACTION', pictureFileUrl: '', soundsCount: 0 },
+        ],
+        OBJECT: [
+          { id: 344, audioFileUrl: '', word: 'вить', wordType: 'OBJECT', pictureFileUrl: '', soundsCount: 0 },
+          { id: 347, audioFileUrl: '', word: 'быль', wordType: 'OBJECT', pictureFileUrl: '', soundsCount: 0 },
+        ],
+      },
+    });
+    this.set('model', model);
+    this.set('onRightAnswer', function () {});
+    this.set('onWrongAnswer', function () {});
+    this.set('onPlayText', function () {});
+  });
+
+  test('it marks each word individually as correct or incorrect when answer is partially wrong', async function (assert) {
+    await render(hbs`
+      <TaskPlayer::WordsSequences
+        @task={{this.model}}
+        @mode="task"
+        @onRightAnswer={{this.onRightAnswer}}
+        @onWrongAnswer={{this.onWrongAnswer}}
+        @onPlayText={{this.onPlayText}}
+      />
+    `);
+
+    // Read the correct answer set by the component on document.body
+    const correctAnswer = document.body.dataset.correctAnswer.split(',');
+    // correctAnswer[0] = correct OBJECT word, correctAnswer[1] = correct OBJECT_ACTION word
+    const correctObjectWord = correctAnswer[0];
+    const correctActionWord = correctAnswer[1];
+
+    // Find a wrong word for OBJECT_ACTION type
+    const allActionWords = this.model.answerOptions.OBJECT_ACTION.map(o => o.word);
+    const wrongActionWord = allActionWords.find(w => w !== correctActionWord);
+
+    // Click the CORRECT word for OBJECT type
+    await click(`[data-test-task-answer-option="${correctObjectWord}"]`);
+
+    // Click a WRONG word for OBJECT_ACTION type
+    // Don't await — we need to inspect the DOM before handleWrongAnswer resets correctnessPerType
+    click(`[data-test-task-answer-option="${wrongActionWord}"]`);
+
+    // Wait for correctness indicators to appear
+    await waitFor('.correctness-indicator', { timeout: 2000 });
+
+    // Correct word should have green border
+    assert.dom(`[data-test-task-answer-option="${correctObjectWord}"]`).hasClass(
+      'border-green-500',
+      'Correctly answered word should have green border'
+    );
+
+    // Wrong word should have red border
+    assert.dom(`[data-test-task-answer-option="${wrongActionWord}"]`).hasClass(
+      'border-red-500',
+      'Incorrectly answered word should have red border'
+    );
+
+    // Let all pending async operations settle
+    await settled();
   });
 });


### PR DESCRIPTION
Previously, a single isCorrect boolean was shared across all word columns, causing all words to show red X marks if any single word was wrong. Now each word type is independently validated via correctnessPerType, so correct words show green checkmarks and incorrect words show red X marks.

fixes https://github.com/Brain-up/brn/issues/2718