### PR TITLE
Fix statistics showing 00:00 after midnight for non-UTC timezones

### DIFF
--- a/frontend/app/adapters/user-daily-time-table-statistics.ts
+++ b/frontend/app/adapters/user-daily-time-table-statistics.ts
@@ -10,7 +10,7 @@ export default class UserDailyTimeTableStatisticsAdapter extends ApplicationAdap
     day: string;
   } {
     return {
-      day: query.day.toUTC().toFormat('yyyy-MM-dd\'T\'HH:mm:ss'),
+      day: query.day.toFormat('yyyy-MM-dd'),
     };
   }
 }

--- a/frontend/app/adapters/user-weekly-statistics.ts
+++ b/frontend/app/adapters/user-weekly-statistics.ts
@@ -11,8 +11,8 @@ export default class UserWeeklyStatisticsAdapter extends ApplicationAdapter {
     to: string;
   } {
     const newQuery = {
-      from: query.from.toUTC().toFormat('yyyy-MM-dd\'T\'HH:mm:ss'),
-      to: query.to.toUTC().toFormat('yyyy-MM-dd\'T\'HH:mm:ss'),
+      from: query.from.toFormat('yyyy-MM-dd'),
+      to: query.to.toFormat('yyyy-MM-dd'),
     };
     return newQuery;
   }

--- a/frontend/app/transforms/full-date.ts
+++ b/frontend/app/transforms/full-date.ts
@@ -8,7 +8,7 @@ class FullDate extends DateTransform {
     const browserLocale  = (navigator && navigator.language) || 'en';
     return (
       (serialized &&
-        DateTime.fromISO(serialized as unknown as string, { zone: 'utc', locale: browserLocale })) ||
+        DateTime.fromISO(serialized as unknown as string, { zone: 'utc', locale: browserLocale }).toLocal()) ||
       null
     );
   }


### PR DESCRIPTION
## Summary

Fixes #2705 — Statistics in the site header display as 00:00 after midnight and sum up with the previous day's data on the "Weekly exercise time" block for users in timezones east of UTC.

**Root cause:** The statistics adapters called `.toUTC()` on local DateTime objects before formatting them as query parameters. For a user in UTC+5 at 1:00 AM local time, the UTC conversion shifted the date to 8:00 PM the **previous day**, causing the API to return yesterday's data instead of today's.

**Changes:**
- **`app/adapters/user-weekly-statistics.ts`** — Remove `.toUTC()` and send date-only strings (`yyyy-MM-dd`) in the user's local timezone instead of UTC datetime strings
- **`app/adapters/user-daily-time-table-statistics.ts`** — Same fix for the daily statistics adapter
- **`app/transforms/full-date.ts`** — Convert API response dates from UTC to local timezone (`.toLocal()`) so that `.day`, `.month`, `.year` comparisons in components are consistent with local `DateTime.now()`

Note: The yearly statistics adapter (`user-yearly-statistics.ts`) inherits from the weekly adapter, so it gets the fix automatically.

## Example

User in UTC+5, local time 2024-01-15 01:00:

| | Before (broken) | After (fixed) |
|---|---|---|
| Query param | `from=2024-12-31T19:00:00` (previous day!) | `from=2024-01-01` (correct) |
| Daily query | `day=2024-01-14T19:00:00` (wrong day!) | `day=2024-01-15` (correct) |
| API response date | Stays in UTC zone | Converted to local zone |

## Test plan

- [ ] Set system timezone to UTC+5 (or any positive offset)
- [ ] Complete an exercise after midnight local time
- [ ] Verify header timer shows actual exercise time, not 00:00
- [ ] Verify weekly exercise time block shows today's data on the correct day
- [ ] Verify statistics page displays correctly for the current month
- [ ] Test with UTC-5 timezone to ensure western timezones also work correctly
- [ ] Verify month/year navigation on the statistics page still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)