### PR TITLE
Fix Continue button text clipped on mobile

### DIFF
--- a/frontend/app/components/exercise-stats/template.hbs
+++ b/frontend/app/components/exercise-stats/template.hbs
@@ -23,6 +23,7 @@
     <div class="flex items-center justify-center">
       <Ui::Button
         data-test-continue
+        class="w-auto px-8"
         @title={{t "statistics.continue"}}
         {{on "click" @onComplete}}
       />


### PR DESCRIPTION
## Summary
- Add `w-auto px-8` to the exercise-stats "Continue" button to prevent text clipping on mobile
- The `Ui::Button` component defaults to `w-1/4` (25% parent width), which is too narrow on mobile screens to display "Продолжить" / "Continue" fully
- `w-auto` sizes the button to fit its content, `px-8` adds horizontal padding

Closes #2703

## Test plan
- [ ] Open exercise on mobile viewport → complete exercise → verify "Continue" / "Продолжить" button text is fully visible
- [ ] Verify button still looks correct on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)