### PR TITLE
Fix idle pause during LISTEN audio gaps (followup to #2893)

### DIFF
--- a/frontend/app/services/audio.ts
+++ b/frontend/app/services/audio.ts
@@ -34,6 +34,7 @@ import type { Signal as SignalModel } from 'brn/schemas/signal';
 import Intl from 'ember-intl/services/intl';
 import { PolySynth, Synth, SynthOptions } from 'tone';
 import UserDataService from './user-data';
+import StudyingTimerService from './studying-timer';
 import type { Exercise } from 'brn/schemas/exercise';
 
 type ISourceCollection = (ISource | IToneSource | null)[];
@@ -52,6 +53,7 @@ export default class AudioService extends Service {
   @service('stats') declare stats: StatsService;
   @service('intl') declare intl: Intl;
   @service('user-data') declare userData: UserDataService;
+  @service('studying-timer') declare studyingTimer: StudyingTimerService;
   context!: AudioContext;
 
   willDestroy(): void {
@@ -218,6 +220,7 @@ export default class AudioService extends Service {
 
   @action
   async playAudio() {
+    this.studyingTimer.resetIdle();
     try {
       if (!isTesting()) {
         await this.playTask.perform();

--- a/frontend/app/services/studying-timer.ts
+++ b/frontend/app/services/studying-timer.ts
@@ -66,12 +66,26 @@ export default class StudyingTimerService extends Service {
   }
   @action
   maybeIdlePause() {
-    // Pause cascades into audio.stop() via task-player.onPauseStateChanged,
-    // which would interrupt exercises whenever the user stops moving the mouse.
+    // resetIdle() (invoked on every playAudio) is the primary mechanism that
+    // keeps the watcher from firing mid-sequence. This guard is a defensive
+    // backstop in case a single clip ever outruns the idle window: pause
+    // cascades into audio.stop() via task-player.onPauseStateChanged, which
+    // would interrupt exercises whenever the user stops moving the mouse.
     if (this.audio.isPlaying) {
       return;
     }
     this.pause();
+  }
+  @action
+  resetIdle() {
+    if (this.idleWatcher) {
+      try {
+        this.idleWatcher.stop();
+        this.idleWatcher.start();
+      } catch (_e) {
+        // idle-js may not support stop/start cycle in some edge cases
+      }
+    }
   }
   @action
   async startIdleWatcher() {

--- a/frontend/tests/unit/services/studying-timer-test.js
+++ b/frontend/tests/unit/services/studying-timer-test.js
@@ -36,4 +36,43 @@ module('Unit | Service | studying-timer', function (hooks) {
       assert.true(timer.isPaused);
     });
   });
+
+  module('resetIdle', function () {
+    test('rearms the idle watcher via stop/start', function (assert) {
+      const timer = this.owner.lookup('service:studying-timer');
+      let stopCount = 0;
+      let startCount = 0;
+      timer.idleWatcher = {
+        stop() {
+          stopCount++;
+        },
+        start() {
+          startCount++;
+        },
+      };
+      timer.resetIdle();
+      assert.strictEqual(stopCount, 1, 'idleWatcher.stop called once');
+      assert.strictEqual(startCount, 1, 'idleWatcher.start called once');
+    });
+
+    test('does not toggle isPaused', function (assert) {
+      // Regression guard: resetIdle must not clear a user-initiated pause.
+      const timer = this.owner.lookup('service:studying-timer');
+      timer.idleWatcher = { stop() {}, start() {} };
+      timer.pause();
+      timer.resetIdle();
+      assert.true(timer.isPaused, 'user pause remains sticky after resetIdle');
+    });
+
+    test('is a no-op when idleWatcher is null', function (assert) {
+      const timer = this.owner.lookup('service:studying-timer');
+      timer.idleWatcher = null;
+      try {
+        timer.resetIdle();
+        assert.ok(true, 'did not throw');
+      } catch (_e) {
+        assert.ok(false, 'resetIdle threw with null idleWatcher');
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Followup to #2893. That PR's `maybeIdlePause()` guard only checks `audio.isPlaying` at the **instant** IdleJs fires, but in `listenModeTask` `isPlaying` is `false` during the 1500 ms gap between clips and during `setAudioElements` decoding. With `idleTimeout: 10000`, after ~3 clips `onIdle` lands in the gap, pauses, and `listenModeTask` deadlocks in `waitWhilePaused()` (IdleJs does not reschedule `onIdle` without a user input event).
- Add `studyingTimer.resetIdle()` that rearms the watcher via `stop().start()`, called from `audio.playAudio()` — the single funnel all three audio entry points go through (`startPlayTask`, `listenModeTask`'s direct call, `interactModeTask`'s direct call). Every clip resets the 10 s countdown.
- `resetIdle()` deliberately does **not** touch `isPaused` — user-initiated pause must remain sticky (the f9c43aa8 regression test still passes).
- `maybeIdlePause()` is kept as a defensive backstop for the unlikely case of a single clip exceeding the idle window.

## Test plan

- [x] `pnpm lint:types` — clean.
- [x] `pnpm test:ember --filter studying-timer` — 8/8 pass (5 existing + 3 new tests for `resetIdle`: rearm via stop/start, no-toggle of `isPaused` regression guard, no-op when `idleWatcher` is null).
- [x] `pnpm test:ember --filter audio --filter task-player` — 109/109 pass. Circular service injection (audio ↔ studying-timer) resolves lazily.
- [x] Browser verification on dev: start task, do not touch mouse for 32 s. LISTEN played all 3 clips, timer counted 00:00 → 00:18 with `isPaused=false` throughout, transitioned to INTERACT, then idle correctly paused at ~10 s of inactivity. Click on a word resumed normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)