### PR TITLE
Fix background noise not playing after a page refresh

### DIFF
--- a/frontend/app/services/audio.ts
+++ b/frontend/app/services/audio.ts
@@ -365,6 +365,14 @@ export default class AudioService extends Service {
         return;
       }
       noise = await this.getNoise(timeInSeconds, level, url);
+      // Mirror the word-playback path: a fresh AudioContext (e.g. right after a
+      // page refresh) starts suspended under the browser autoplay policy, and
+      // source.start(0) on a suspended context queues silently. Resume before
+      // starting so background noise plays on first load — not only after a
+      // lesson restart, which happened to reuse an already-resumed context.
+      if (this.context && this.context.state === 'suspended' && !isTesting()) {
+        await this.context.resume();
+      }
       noise.source.start(0);
       this.noiseNode = noise;
       if (url) {

--- a/frontend/app/services/audio.ts
+++ b/frontend/app/services/audio.ts
@@ -355,6 +355,7 @@ export default class AudioService extends Service {
 
   startNoiseTask = task(async () => {
     let noise = null;
+    let started = false;
     const timeInSeconds = 10;
     try {
       const [level, url] = [
@@ -374,6 +375,7 @@ export default class AudioService extends Service {
         await this.context.resume();
       }
       noise.source.start(0);
+      started = true;
       this.noiseNode = noise;
       if (url) {
         await timeout(toMilliseconds(6000));
@@ -382,7 +384,11 @@ export default class AudioService extends Service {
         this.startNoise();
       }
     } finally {
-      if (noise) {
+      // Only stop a source that actually started. The context.resume() above
+      // adds an await between creating and starting the source, so a cancel
+      // (e.g. stopNoise) or a resume rejection in that window would otherwise
+      // call stop() on a never-started node and throw InvalidStateError.
+      if (noise && started) {
         noise.source.stop();
       }
     }

--- a/frontend/tests/unit/services/audio-test.js
+++ b/frontend/tests/unit/services/audio-test.js
@@ -290,7 +290,6 @@ module('Unit | Service | audio', function (hooks) {
 
   module('startNoiseTask', function () {
     test('does not create or start noise when the exercise has no noise level', async function (assert) {
-      const events = [];
       class TestAudioService extends AudioService {
         get currentExerciseNoiseLevel() {
           return 0;
@@ -299,7 +298,7 @@ module('Unit | Service | audio', function (hooks) {
           return null;
         }
         async getNoise() {
-          events.push('getNoise');
+          assert.step('getNoise');
           return { source: { start() {}, stop() {} }, gainNode: {} };
         }
       }
@@ -308,11 +307,10 @@ module('Unit | Service | audio', function (hooks) {
 
       await service.startNoiseTask.perform();
 
-      assert.deepEqual(events, [], 'no noise is created when the level is 0');
+      assert.verifySteps([], 'no noise is created when the level is 0');
     });
 
     test('creates and starts the noise source when the exercise has a noise level', async function (assert) {
-      const events = [];
       class TestAudioService extends AudioService {
         get currentExerciseNoiseLevel() {
           return 50;
@@ -321,14 +319,14 @@ module('Unit | Service | audio', function (hooks) {
           return 'http://example.com/noise.mp3';
         }
         async getNoise() {
-          events.push('getNoise');
+          assert.step('getNoise');
           return {
             source: {
               start() {
-                events.push('start');
+                assert.step('start');
               },
               stop() {
-                events.push('stop');
+                assert.step('stop');
               },
             },
             gainNode: {},
@@ -351,11 +349,10 @@ module('Unit | Service | audio', function (hooks) {
         // cancellation is expected
       }
 
-      assert.true(events.includes('getNoise'), 'noise source is created');
-      assert.true(events.includes('start'), 'noise source is started');
-      assert.ok(
-        events.indexOf('getNoise') < events.indexOf('start'),
-        'noise is created before it is started',
+      // Ordered: the source is created, then started, then stopped on cancel.
+      assert.verifySteps(
+        ['getNoise', 'start', 'stop'],
+        'noise is created before it is started, and stopped on cancellation',
       );
     });
   });

--- a/frontend/tests/unit/services/audio-test.js
+++ b/frontend/tests/unit/services/audio-test.js
@@ -287,4 +287,76 @@ module('Unit | Service | audio', function (hooks) {
       );
     });
   });
+
+  module('startNoiseTask', function () {
+    test('does not create or start noise when the exercise has no noise level', async function (assert) {
+      const events = [];
+      class TestAudioService extends AudioService {
+        get currentExerciseNoiseLevel() {
+          return 0;
+        }
+        get currentExerciseNoiseUrl() {
+          return null;
+        }
+        async getNoise() {
+          events.push('getNoise');
+          return { source: { start() {}, stop() {} }, gainNode: {} };
+        }
+      }
+      this.owner.register('service:audio', TestAudioService);
+      const service = this.owner.lookup('service:audio');
+
+      await service.startNoiseTask.perform();
+
+      assert.deepEqual(events, [], 'no noise is created when the level is 0');
+    });
+
+    test('creates and starts the noise source when the exercise has a noise level', async function (assert) {
+      const events = [];
+      class TestAudioService extends AudioService {
+        get currentExerciseNoiseLevel() {
+          return 50;
+        }
+        get currentExerciseNoiseUrl() {
+          return 'http://example.com/noise.mp3';
+        }
+        async getNoise() {
+          events.push('getNoise');
+          return {
+            source: {
+              start() {
+                events.push('start');
+              },
+              stop() {
+                events.push('stop');
+              },
+            },
+            gainNode: {},
+          };
+        }
+      }
+      this.owner.register('service:audio', TestAudioService);
+      const service = this.owner.lookup('service:audio');
+      // A running context is the post-restart case; the suspended-context
+      // resume is production-only (guarded by !isTesting()).
+      service.context = { state: 'running', resume: () => Promise.resolve() };
+
+      const instance = service.startNoiseTask.perform();
+      // The task loops on timeout(6000) after starting; cancel once started.
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      instance.cancel();
+      try {
+        await instance;
+      } catch (_e) {
+        // cancellation is expected
+      }
+
+      assert.true(events.includes('getNoise'), 'noise source is created');
+      assert.true(events.includes('start'), 'noise source is started');
+      assert.ok(
+        events.indexOf('getNoise') < events.indexOf('start'),
+        'noise is created before it is started',
+      );
+    });
+  });
 });

--- a/frontend/tests/unit/services/audio-test.js
+++ b/frontend/tests/unit/services/audio-test.js
@@ -336,8 +336,13 @@ module('Unit | Service | audio', function (hooks) {
       this.owner.register('service:audio', TestAudioService);
       const service = this.owner.lookup('service:audio');
       // A running context is the post-restart case; the suspended-context
-      // resume is production-only (guarded by !isTesting()).
-      service.context = { state: 'running', resume: () => Promise.resolve() };
+      // resume is production-only (guarded by !isTesting()). close() is needed
+      // because the service's willDestroy() closes the context on teardown.
+      service.context = {
+        state: 'running',
+        resume: () => Promise.resolve(),
+        close: () => Promise.resolve(),
+      };
 
       const instance = service.startNoiseTask.perform();
       // The task loops on timeout(6000) after starting; cancel once started.


### PR DESCRIPTION
## Problem
After **refreshing** the exercise page, the background noise (шум, played behind the words to simulate a noisy listening environment) doesn't play. Restarting the lesson fixes it.

## Root cause
The `AudioService` is a singleton whose `AudioContext` lives for the page's lifetime. Browsers create an `AudioContext` in the **`suspended`** state under the autoplay policy — it only produces sound after an explicit `resume()`.

The **word-playback** path resumes it (`setAudioElements` and `playTask` both call `context.resume()` on a suspended context). The **noise** path never does — `startNoiseTask` calls `noise.source.start(0)` with no resume. On a hard refresh the context is fresh/suspended when the noise source starts, so it's scheduled but silent. A restart reuses a context that word playback already resumed, which is exactly why restarting "fixes" it.

(The `if (!level) return` guard on `currentExerciseNoiseLevel` was considered and ruled out — it would suppress noise in *both* flows, so it can't explain the refresh-vs-restart difference.)

## Fix
Resume the context before starting the noise source in `startNoiseTask`, mirroring the existing suspended-state handling in `setAudioElements`/`playTask` (same `!isTesting()` guard).

```js
if (this.context && this.context.state === 'suspended' && !isTesting()) {
  await this.context.resume();
}
noise.source.start(0);
```

## Tests
Adds `startNoiseTask` coverage: the no-noise-level early return, and that the noise source is created and started when a noise level is present.

## Verification
`lint:types` (glint/tsc) and `eslint` pass clean. The QUnit suite was **not** run — `ember test` is broken pre-existing in this repo (aborts on a global `./package` module error before any test runs).

Worth a quick manual check: hard-refresh directly on an exercise with noise, start it, and confirm the background noise plays on the first pass (not only after a restart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)